### PR TITLE
Add concrete `RuntimeMetricsIter` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ macro_rules! cfg_rt {
 cfg_rt! {
     mod runtime;
     pub use runtime::{
+        RuntimeIntervals,
         RuntimeMetrics,
-        RuntimeMetricsIter,
         RuntimeMonitor,
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ cfg_rt! {
     mod runtime;
     pub use runtime::{
         RuntimeMetrics,
+        RuntimeMetricsIter,
         RuntimeMonitor,
     };
 }


### PR DESCRIPTION
Using return-position-impl-trait for the iterator returned by `RuntimeMonitor::intervals` means that users can't name the type to store it without boxing the iterator. I'd like to be able to do that in a [crate to add Prometheus integration][tokio-metrics-prometheus] ideally (although boxing isn't really the end of the world there).

[tokio-metrics-prometheus]: https://github.com/sd2k/tokio-metrics-prometheus
