### PR TITLE
Fix the description of steal_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,11 @@ tokio::spawn(do_work());
 - **[`min_noop_count`]**  
   The minimum number of times any worker thread unparked but performed no work before parking again.
 - **[`total_steal_count`]**  
-  The number of times worker threads stole tasks from another worker thread.
+  The number of tasks worker threads stole from another worker thread.
 - **[`max_steal_count`]**  
-  The maximum number of times any worker thread stole tasks from another worker thread.
+  The maximum number of tasks any worker thread stole from another worker thread.
 - **[`min_steal_count`]**  
-  The minimum number of times any worker thread stole tasks from another worker thread.
+  The minimum number of tasks any worker thread stole from another worker thread.
 - **[`num_remote_schedules`]**  
   The number of tasks scheduled from outside of the runtime.
 - **[`total_local_schedule_count`]**  

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -254,10 +254,11 @@ pub struct RuntimeMetrics {
     /// - [`RuntimeMetrics::max_noop_count`]
     pub min_noop_count: u64,
 
-    /// The number of times worker threads stole tasks from another worker thread.
+    /// The number of tasks worker threads stole from another worker thread.
     ///
-    /// The worker steal count starts increases by one each time the worker has processed its 
-    /// scheduled queue and successfully steals more pending tasks from another worker.
+    /// The worker steal count starts increases by the amount of stolen tasks each time the worker
+    /// has processed its scheduled queue and successfully steals more pending tasks from another
+    /// worker.
     /// 
     /// This metric only applies to the **multi-threaded** runtime and will always return `0` when 
     /// using the current thread runtime.
@@ -297,7 +298,7 @@ pub struct RuntimeMetrics {
     ///             // Spawn a task that bumps the previous task out of the "next
     ///             // scheduled" slot.
     ///             tokio::spawn(async {});
-    ///             // Blocking receive on the channe.
+    ///             // Blocking receive on the channel.
     ///             rx.recv().unwrap();
     ///             flush_metrics().await;
     ///         }).await.unwrap();
@@ -321,7 +322,7 @@ pub struct RuntimeMetrics {
     /// ```
     pub total_steal_count: u64,
 
-    /// The maximum number of times any worker thread stole tasks from another worker thread.
+    /// The maximum number of tasks any worker thread stole from another worker thread.
     /// 
     /// ##### Definition
     /// This metric is derived from the maximum of [`tokio::runtime::RuntimeMetrics::worker_steal_count`] 
@@ -332,7 +333,7 @@ pub struct RuntimeMetrics {
     /// - [`RuntimeMetrics::min_steal_count`]
     pub max_steal_count: u64,
 
-    /// The minimum number of times any worker thread stole tasks from another worker thread.
+    /// The minimum number of tasks any worker thread stole from another worker thread.
     /// 
     /// ##### Definition
     /// This metric is derived from the minimum of [`tokio::runtime::RuntimeMetrics::worker_steal_count`] 

--- a/src/task.rs
+++ b/src/task.rs
@@ -2431,7 +2431,7 @@ impl ArcWake for State {
 #[inline(always)]
 fn to_nanos(d: Duration) -> u64 {
     debug_assert!(d <= Duration::from_nanos(u64::MAX));
-    (d.as_secs() as u64)
+    d.as_secs()
         .wrapping_mul(1_000_000_000)
         .wrapping_add(d.subsec_nanos() as u64)
 }


### PR DESCRIPTION
- `steal_count` falsely claimed to be the number of times tasks were stolen, but was actually the number of tasks stolen. Adjust the documentation to reflect this fact
- ~~Expose the new `steal_operations` metric, which tracks what was previously documented to be `steal_count`. This requires [#5330](https://github.com/tokio-rs/tokio/pull/5330), so I guess it might make sense for me to split that part into a separate PR since it requires bumping the minimum supported tokio version.~~ Edit: Removed this part and kept only the documentation changes.