### PR TITLE
chore: prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# 0.2.0 (March 6th, 2023)
+
+### Added
+- Add `Debug` implementations. ([#28])
+- rt: add concrete `RuntimeIntervals` iterator type ([#26])
+- rt: add budget_forced_yield_count metric ([#39])
+- rt: add io_driver_ready_count metric ([#40])
+- rt: add steal_operations metric ([#37])
+- task: also instrument streams ([#31])
+
+### Documented
+- doc: fix count in `TaskMonitor` docstring ([#24])
+- doc: the description of steal_count ([#35])
+
+[#24]: https://github.com/tokio-rs/tokio-metrics/pull/24
+[#26]: https://github.com/tokio-rs/tokio-metrics/pull/26
+[#28]: https://github.com/tokio-rs/tokio-metrics/pull/28
+[#31]: https://github.com/tokio-rs/tokio-metrics/pull/31
+[#35]: https://github.com/tokio-rs/tokio-metrics/pull/35
+[#37]: https://github.com/tokio-rs/tokio-metrics/pull/37
+[#39]: https://github.com/tokio-rs/tokio-metrics/pull/39
+[#40]: https://github.com/tokio-rs/tokio-metrics/pull/40

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-metrics"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ runtime and per-task metrics.
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.1.0", default-features = false }
+tokio-metrics = { version = "0.2.0", default-features = false }
 ```
 
 ## Getting Started With Task Metrics
@@ -84,27 +84,27 @@ loop {
 - **[`mean_slow_poll_duration`]**  
   The mean duration of slow polls.
 
-[`instrumented_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
-[`dropped_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count
-[`first_poll_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.first_poll_count
-[`total_first_poll_delay`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_first_poll_delay 
-[`total_idled_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idled_count
-[`total_idle_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idle_duration 
-[`total_scheduled_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_count 
-[`total_scheduled_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_duration
-[`total_poll_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_count
-[`total_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_duration
-[`total_fast_poll_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_count 
-[`total_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_duration 
-[`total_slow_poll_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_count
-[`total_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_duration 
-[`mean_first_poll_delay`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_first_poll_delay
-[`mean_idle_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_idle_duration
-[`mean_scheduled_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_scheduled_duration
-[`mean_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_poll_duration
-[`slow_poll_ratio`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.slow_poll_ratio
-[`mean_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_fast_poll_duration
-[`mean_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.TaskMetrics.html#method.mean_slow_poll_duration
+[`instrumented_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
+[`dropped_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count
+[`first_poll_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.first_poll_count
+[`total_first_poll_delay`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_first_poll_delay 
+[`total_idled_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idled_count
+[`total_idle_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idle_duration 
+[`total_scheduled_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_count 
+[`total_scheduled_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_duration
+[`total_poll_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_count
+[`total_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_duration
+[`total_fast_poll_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_count 
+[`total_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_duration 
+[`total_slow_poll_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_count
+[`total_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_duration 
+[`mean_first_poll_delay`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_first_poll_delay
+[`mean_idle_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_idle_duration
+[`mean_scheduled_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_scheduled_duration
+[`mean_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_poll_duration
+[`slow_poll_ratio`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.slow_poll_ratio
+[`mean_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_fast_poll_duration
+[`mean_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_slow_poll_duration
 
 ## Getting Started With Runtime Metrics
 
@@ -136,7 +136,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.1.0"
+tokio-metrics = "0.2.0"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of
@@ -224,44 +224,50 @@ tokio::spawn(do_work());
   The minimum number of tasks currently scheduled any worker's local queue.
 - **[`elapsed`]**  
   Total amount of time elapsed since observing runtime metrics.
+- **[`budget_forced_yield_count`]**
+  The number of times that a task was forced to yield because it exhausted its budget.
+- **[`io_driver_ready_count`]**
+  The number of ready events received from the I/O driver.
 
 #### Derived Metrics
 - **[`mean_polls_per_park`]**
 - **[`busy_ratio`]**
 
-[`workers_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
-[`total_park_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
-[`max_park_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_park_count
-[`min_park_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_park_count
-[`total_noop_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_noop_count
-[`max_noop_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_noop_count
-[`min_noop_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_noop_count
-[`total_steal_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_count
-[`max_steal_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_count
-[`min_steal_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_count
-[`total_steal_operations`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_operations
-[`max_steal_operations`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_operations
-[`min_steal_operations`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_operations
-[`num_remote_schedules`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.num_remote_schedules
-[`total_local_schedule_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_schedule_count
-[`max_local_schedule_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_schedule_count
-[`min_local_schedule_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_schedule_count
-[`total_overflow_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_overflow_count
-[`max_overflow_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_overflow_count
-[`min_overflow_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_overflow_count
-[`total_polls_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_polls_count
-[`max_polls_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_polls_count
-[`min_polls_count`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_polls_count
-[`total_busy_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_busy_duration
-[`max_busy_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_busy_duration
-[`min_busy_duration`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_busy_duration
-[`injection_queue_depth`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.injection_queue_depth
-[`total_local_queue_depth`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_queue_depth
-[`max_local_queue_depth`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_queue_depth
-[`min_local_queue_depth`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_queue_depth
-[`elapsed`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.elapsed
-[`mean_polls_per_park`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#method.mean_polls_per_park
-[`busy_ratio`]: https://docs.rs/tokio-metrics/0.1.*/tokio_metrics/struct.RuntimeMetrics.html#method.busy_ratio
+[`workers_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
+[`total_park_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
+[`max_park_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_park_count
+[`min_park_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_park_count
+[`total_noop_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_noop_count
+[`max_noop_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_noop_count
+[`min_noop_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_noop_count
+[`total_steal_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_count
+[`max_steal_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_count
+[`min_steal_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_count
+[`total_steal_operations`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_operations
+[`max_steal_operations`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_operations
+[`min_steal_operations`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_operations
+[`num_remote_schedules`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.num_remote_schedules
+[`total_local_schedule_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_schedule_count
+[`max_local_schedule_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_schedule_count
+[`min_local_schedule_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_schedule_count
+[`total_overflow_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_overflow_count
+[`max_overflow_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_overflow_count
+[`min_overflow_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_overflow_count
+[`total_polls_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_polls_count
+[`max_polls_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_polls_count
+[`min_polls_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_polls_count
+[`total_busy_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_busy_duration
+[`max_busy_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_busy_duration
+[`min_busy_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_busy_duration
+[`injection_queue_depth`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.injection_queue_depth
+[`total_local_queue_depth`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_queue_depth
+[`max_local_queue_depth`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_queue_depth
+[`min_local_queue_depth`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_queue_depth
+[`elapsed`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.elapsed
+[`mean_polls_per_park`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#method.mean_polls_per_park
+[`busy_ratio`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#method.busy_ratio
+[`budget_forced_yield_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.budget_forced_yield_count
+[`io_driver_ready_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.io_driver_ready_count
 
 
 ## Relation to Tokio Console


### PR DESCRIPTION
# 0.2.0 (March 6th, 2023)

### Added
- Add `Debug` implementations. ([#28])
- rt: add concrete `RuntimeIntervals` iterator type ([#26])
- rt: add budget_forced_yield_count metric ([#39])
- rt: add io_driver_ready_count metric ([#40])
- rt: add steal_operations metric ([#37])
- task: also instrument streams ([#31])

### Documented
- doc: fix count in `TaskMonitor` docstring ([#24])
- doc: the description of steal_count ([#35])

[#24]: https://github.com/tokio-rs/tokio-metrics/pull/24
[#26]: https://github.com/tokio-rs/tokio-metrics/pull/26
[#28]: https://github.com/tokio-rs/tokio-metrics/pull/28
[#31]: https://github.com/tokio-rs/tokio-metrics/pull/31
[#35]: https://github.com/tokio-rs/tokio-metrics/pull/35
[#37]: https://github.com/tokio-rs/tokio-metrics/pull/37
[#39]: https://github.com/tokio-rs/tokio-metrics/pull/39
[#40]: https://github.com/tokio-rs/tokio-metrics/pull/40
