### PR TITLE
task: add tail metrics for scheduling delay and poll duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,3 +120,5 @@ cfg_rt! {
 
 mod task;
 pub use task::{Instrumented, TaskMetrics, TaskMonitor};
+
+mod stat_util;

--- a/src/stat_util.rs
+++ b/src/stat_util.rs
@@ -1,0 +1,13 @@
+/// Finds the value for the given tail percentile.
+///
+/// For example, if the 90th percentile is used, the top 10% of values should fall above the value
+/// shown.
+///
+/// # Note
+/// This assumes pre-sorted data
+pub(crate) fn find_percentile<T>(data: &mut [T], percentile: f64) -> T
+where
+    T: Ord + PartialOrd + PartialEq + Clone,
+{
+    data[((data.len() - 1) as f64 * percentile) as usize].clone()
+}


### PR DESCRIPTION
This adds P90, P95, and P99 metrics for these data points so that users can better understand potential causes of tail latency within their applications.