### PR TITLE
task: add short and long delay metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ loop {
   The total number of times that polling tasks completed slowly.
 - **[`total_slow_poll_duration`]**
   The total duration of slow polls.
+- **[`total_short_delay_count`]**
+  The total count of short scheduling delays.
+- **[`total_short_delay_duration`]**
+  The total duration of short scheduling delays.
+- **[`total_long_delay_count`]**
+  The total count of long scheduling delays.
+- **[`total_long_delay_duration`]**
+  The total duration of long scheduling delays.
 
 #### Derived Metrics
 - **[`mean_first_poll_delay`]**  
@@ -83,6 +91,12 @@ loop {
   The mean duration of fast polls.
 - **[`mean_slow_poll_duration`]**  
   The mean duration of slow polls.
+- **[`long_delay_ratio`]**
+- The ratio between the number of long scheduling delays and the number of total schedules.
+- **[`mean_short_delay_duration`]**
+  The mean duration of short schedules.
+- **[`mean_long_delay_duration`]**
+  The mean duration of long schedules.
 
 [`instrumented_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
 [`dropped_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count
@@ -105,6 +119,13 @@ loop {
 [`slow_poll_ratio`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.slow_poll_ratio
 [`mean_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_fast_poll_duration
 [`mean_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_slow_poll_duration
+[`total_short_delay_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_count
+[`total_short_delay_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_duration
+[`total_long_delay_count`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_count
+[`total_long_delay_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_duration
+[`long_delay_ratio`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.long_delay_ratio
+[`mean_short_delay_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_short_delay_duration
+[`mean_long_delay_duration`]: https://docs.rs/tokio-metrics/0.2.*/tokio_metrics/struct.TaskMetrics.html#method.mean_long_delay_duration
 
 ## Getting Started With Runtime Metrics
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -905,6 +905,7 @@ pub struct TaskMetrics {
     ///     assert_eq!(metrics_monitor.cumulative().total_scheduled_count, 5);
     /// }
     /// ```
+    #[doc(alias = "total_delay_count")]
     pub total_scheduled_count: u64,
 
     /// The total duration that tasks spent waiting to be polled after awakening.
@@ -941,6 +942,7 @@ pub struct TaskMetrics {
     ///     assert!(total_scheduled_duration <= Duration::from_millis(1100));
     /// }
     /// ```
+    #[doc(alias = "total_delay_duration")]
     pub total_scheduled_duration: Duration,
 
     /// The total number of times that tasks were polled.

--- a/src/task.rs
+++ b/src/task.rs
@@ -1118,13 +1118,6 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_count: u64,
 
-    /// The total count of tasks with short scheduling delays.
-    ///
-    /// This is defined as tasks taking strictly less than
-    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
-    /// scheduled.
-    pub total_short_delay_count: u64,
-
     /// The total duration of fast polls.
     ///
     /// Here, 'fast' is defined as completing in strictly less time than
@@ -1192,13 +1185,6 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_duration: Duration,
 
-    /// The total duration of tasks with short scheduling delays.
-    ///
-    /// This is defined as tasks taking strictly less than
-    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
-    /// scheduled.
-    pub total_short_delay_duration: Duration,
-
     /// The total number of times that polling tasks completed slowly.
     ///
     /// Here, 'slowly' is defined as completing in at least as much time as
@@ -1253,13 +1239,6 @@ pub struct TaskMetrics {
     /// }
     /// ```
     pub total_slow_poll_count: u64,
-
-    /// The total count of tasks with long scheduling delays.
-    ///
-    /// This is defined as tasks taking
-    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] or longer to be executed
-    /// after being scheduled.
-    pub total_long_delay_count: u64,
 
     /// The total duration of slow polls.
     ///
@@ -1331,10 +1310,47 @@ pub struct TaskMetrics {
     /// ```
     pub total_slow_poll_duration: Duration,
 
+    /// The total count of tasks with short scheduling delays.
+    ///
+    /// This is defined as tasks taking strictly less than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
+    /// scheduled.
+    ///
+    /// ##### Derived metrics
+    /// - **[`mean_short_delay_duration`][TaskMetrics::mean_short_delay_duration]**   
+    ///   The mean duration of short scheduling delays.
+    pub total_short_delay_count: u64,
+
+    /// The total count of tasks with long scheduling delays.
+    ///
+    /// This is defined as tasks taking
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] or longer to be executed
+    /// after being scheduled.
+    ///
+    /// ##### Derived metrics
+    /// - **[`mean_long_delay_duration`][TaskMetrics::mean_long_delay_duration]**   
+    ///   The mean duration of short scheduling delays.
+    pub total_long_delay_count: u64,
+
+    /// The total duration of tasks with short scheduling delays.
+    ///
+    /// This is defined as tasks taking strictly less than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
+    /// scheduled.
+    ///
+    /// ##### Derived metrics
+    /// - **[`mean_short_delay_duration`][TaskMetrics::mean_short_delay_duration]**   
+    ///   The mean duration of short scheduling delays.
+    pub total_short_delay_duration: Duration,
+
     /// The total number of times that a task had a long scheduling duration.
     ///
     /// Here, a long scheduling duration is defined as taking longer to start execution after
     /// scheduling than [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
+    ///
+    /// ##### Derived metrics
+    /// - **[`mean_long_delay_duration`][TaskMetrics::mean_long_delay_duration]**   
+    ///   The mean duration of short scheduling delays.
     pub total_long_delay_duration: Duration,
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -2164,6 +2164,10 @@ impl TaskMetrics {
     }
 
     /// The ratio of tasks exceeding [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
+    ///
+    /// ##### Definition
+    /// This metric is derived from [`total_long_delay_count`][TaskMetrics::total_long_delay_count] ÷
+    /// [`total_scheduled_count`][TaskMetrics::total_scheduled_count].
     pub fn long_delay_ratio(&self) -> f64 {
         self.total_long_delay_count as f64 / self.total_scheduled_count as f64
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1500,7 +1500,7 @@ impl TaskMonitor {
         self.metrics.slow_poll_threshold
     }
 
-    /// The threshold after which a scheduling delay will be considered "long".
+    /// The threshold at which a scheduling delay will be considered "long".
     pub fn long_delay_threshold(&self) -> Duration {
         self.metrics.long_delay_threshold
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1324,7 +1324,7 @@ struct RawMetrics {
     /// A task poll takes longer than this, it is considered a slow poll.
     slow_poll_threshold: Duration,
 
-    /// A scheduling delay longer than this will be considered a long delay
+    /// A scheduling delay of at least this long will be considered a long delay
     long_delay_threshold: Duration,
 
     /// Total number of instrumented tasks.

--- a/src/task.rs
+++ b/src/task.rs
@@ -1172,9 +1172,9 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_duration: Duration,
 
-    /// The total scheduling duration for tasks which were quickly executed after being scheduled.
+    /// The total duration of tasks with short scheduling delays.
     ///
-    /// Here, "quickly" means that the task takes less than
+    /// This is defined as tasks taking strictly less than
     /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
     /// scheduled.
     pub total_short_delay_duration: Duration,

--- a/src/task.rs
+++ b/src/task.rs
@@ -2445,7 +2445,7 @@ fn instrument_poll<T, Out>(
 
         let scheduled = Duration::from_nanos(scheduled_ns);
 
-        let (count_bucket, duration_bucket) = // was this a slow or fast poll?
+        let (count_bucket, duration_bucket) = // was the scheduling delay long or short?
             if scheduled >= metrics.long_delay_threshold {
                 (&metrics.total_long_delay_count, &metrics.total_long_delay_duration_ns)
             } else {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1236,9 +1236,9 @@ pub struct TaskMetrics {
 
     /// The total count of tasks with long scheduling delays.
     ///
-    /// This is defined as tasks taking longer than
-    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed aftering being
-    /// scheduled.
+    /// This is defined as tasks taking
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] or longer to be executed
+    /// after being scheduled.
     pub total_long_delay_count: u64,
 
     /// The total duration of slow polls.

--- a/src/task.rs
+++ b/src/task.rs
@@ -205,6 +205,16 @@ use std::time::{Duration, Instant};
 ///   'scheduled' state of a task is the duration between the instant a task is awoken and the
 ///   instant it is subsequently polled. If this metric increases, it means that, on average, tasks
 ///   spent longer in tokio's queues before being polled.
+/// - **Did [`long_delay_ratio`][TaskMetrics::long_delay_ratio] increase?**
+///   This metric reflects the proportion of scheduling delays which were 'long'. If it increased,
+///   it means that a greater proportion of tasks experienced excessive delays before they could
+///   execute after being woken. This does not necessarily indicate an increase in latency, as this
+///   could be offset by fewer or faster task polls.
+/// - **Did [`mean_long_delay_duration`][TaskMetrics::mean_long_delay_duration] increase?**
+///   This metric reflects the mean duration of long delays. If it increased, it means that, on
+///   average, long delays got even longer. This does not necessarily imply increased task latency:
+///   an increase in average long delay duration could be offset by fewer or faster polls or more
+///   short schedules.
 ///
 /// If so, [*why are my tasks spending more time waiting to be polled?*](#why-are-my-tasks-spending-more-time-waiting-to-be-polled)
 ///

--- a/src/task.rs
+++ b/src/task.rs
@@ -1536,7 +1536,8 @@ impl TaskMonitor {
         self.metrics.slow_poll_threshold
     }
 
-    /// The threshold at which a scheduling delay will be considered "long".
+    /// Produces the duration greater-than-or-equal-to at which scheduling delays are categorized
+    /// as long.
     pub fn long_delay_threshold(&self) -> Duration {
         self.metrics.long_delay_threshold
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1098,6 +1098,10 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_count: u64,
 
+    /// The total number of times that a task was executed swiftly.
+    ///
+    /// Here, 'swiftly' is defined as executing in strictly less time than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
     pub total_short_delay_count: u64,
 
     /// The total duration of fast polls.
@@ -1167,6 +1171,11 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_duration: Duration,
 
+    /// The total scheduling duration for tasks which were quickly executed after being scheduled.
+    ///
+    /// Here, "quickly" means that the task takes less than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
+    /// scheduled.
     pub total_short_delay_duration: Duration,
 
     /// The total number of times that polling tasks completed slowly.
@@ -1224,6 +1233,11 @@ pub struct TaskMetrics {
     /// ```
     pub total_slow_poll_count: u64,
 
+    /// The total count of tasks with long scheduling delays.
+    ///
+    /// This is defined as tasks taking longer than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed aftering being
+    /// scheduled.
     pub total_long_delay_count: u64,
 
     /// The total duration of slow polls.
@@ -1296,6 +1310,10 @@ pub struct TaskMetrics {
     /// ```
     pub total_slow_poll_duration: Duration,
 
+    /// The total number of times that a task had a long scheduling duration.
+    ///
+    /// Here, a long scheduling duration is defined as taking longer to start execution after
+    /// scheduling than [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
     pub total_long_delay_duration: Duration,
 }
 
@@ -1481,6 +1499,7 @@ impl TaskMonitor {
         self.metrics.slow_poll_threshold
     }
 
+    /// The threshold after which a scheduling delay will be considered "long".
     pub fn long_delay_threshold(&self) -> Duration {
         self.metrics.long_delay_threshold
     }
@@ -2106,8 +2125,9 @@ impl TaskMetrics {
         self.total_slow_poll_count as f64 / self.total_poll_count as f64
     }
 
+    /// The ratio of tasks exceeding [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
     pub fn long_delay_ratio(&self) -> f64 {
-        self.total_long_delay_count as f64 / self.total_poll_count as f64
+        self.total_long_delay_count as f64 / self.total_scheduled_count as f64
     }
 
     /// The mean duration of fast polls.
@@ -2184,6 +2204,8 @@ impl TaskMetrics {
         mean(self.total_fast_poll_duration, self.total_fast_poll_count)
     }
 
+    /// The average time taken for a task with a short scheduling delay to be executed after being
+    /// scheduled.
     pub fn mean_short_poll_duration(&self) -> Duration {
         mean(
             self.total_short_delay_duration,
@@ -2282,6 +2304,8 @@ impl TaskMetrics {
         mean(self.total_slow_poll_duration, self.total_slow_poll_count)
     }
 
+    /// The average scheduling delay for a task which takes a long time to start executing after
+    /// being scheduled.
     pub fn mean_long_delay_duration(&self) -> Duration {
         mean(self.total_long_delay_duration, self.total_long_delay_count)
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1372,7 +1372,7 @@ struct RawMetrics {
     /// Total amount of time tasks spent being polled below the long delay cut off.
     total_short_delay_duration_ns: AtomicU64,
 
-    /// Total amount of time tasks spent being polled above the long delay cut off.
+    /// Total amount of time tasks spent being polled at or above the long delay cut off.
     total_long_delay_duration_ns: AtomicU64,
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -1098,10 +1098,11 @@ pub struct TaskMetrics {
     /// ```
     pub total_fast_poll_count: u64,
 
-    /// The total number of times that a task was executed swiftly.
+    /// The total count of tasks with short scheduling delays.
     ///
-    /// Here, 'swiftly' is defined as executing in strictly less time than
-    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold].
+    /// This is defined as tasks taking strictly less than
+    /// [`long_delay_threshold`][TaskMonitor::long_delay_threshold] to be executed after being
+    /// scheduled.
     pub total_short_delay_count: u64,
 
     /// The total duration of fast polls.

--- a/src/task.rs
+++ b/src/task.rs
@@ -2248,6 +2248,11 @@ impl TaskMetrics {
 
     /// The average time taken for a task with a short scheduling delay to be executed after being
     /// scheduled.
+    ///
+    /// ##### Definition
+    /// This metric is derived from
+    /// [`total_short_delay_duration`][TaskMetrics::total_short_delay_duration] ÷
+    /// [`total_short_delay_count`][TaskMetrics::total_short_delay_count].
     pub fn mean_short_delay_duration(&self) -> Duration {
         mean(
             self.total_short_delay_duration,
@@ -2348,6 +2353,11 @@ impl TaskMetrics {
 
     /// The average scheduling delay for a task which takes a long time to start executing after
     /// being scheduled.
+    ///
+    /// ##### Definition
+    /// This metric is derived from
+    /// [`total_long_delay_duration`][TaskMetrics::total_long_delay_duration] ÷
+    /// [`total_long_delay_count`][TaskMetrics::total_long_delay_count].
     pub fn mean_long_delay_duration(&self) -> Duration {
         mean(self.total_long_delay_duration, self.total_long_delay_count)
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -852,6 +852,10 @@ pub struct TaskMetrics {
     /// The total number of times that tasks were awoken (and then, presumably, scheduled for
     /// execution).
     ///
+    /// ##### Definition
+    /// This metric is equal to [`total_short_delay_duration`][TaskMetrics::total_short_delay_duration]
+    /// + [`total_long_delay_duration`][TaskMetrics::total_long_delay_duration].
+    ///
     /// ##### Derived metrics
     /// - **[`mean_scheduled_duration`][TaskMetrics::mean_scheduled_duration]**   
     ///   The mean duration that tasks spent waiting to be executed after awakening.
@@ -919,6 +923,10 @@ pub struct TaskMetrics {
     pub total_scheduled_count: u64,
 
     /// The total duration that tasks spent waiting to be polled after awakening.
+    ///
+    /// ##### Definition
+    /// This metric is equal to [`total_short_delay_count`][TaskMetrics::total_short_delay_count]
+    /// + [`total_long_delay_count`][TaskMetrics::total_long_delay_count].
     ///
     /// ##### Derived metrics
     /// - **[`mean_scheduled_duration`][TaskMetrics::mean_scheduled_duration]**   


### PR DESCRIPTION
This adds short and long scheduler delay metrics, paralleling fast and slow poll metrics.