### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.1 (April 5th, 2023)
+
+### Added
+- task: add short and long delay metrics ([#44])
+
+[#44]: https://github.com/tokio-rs/tokio-metrics/pull/44
+
 # 0.2.0 (March 6th, 2023)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-metrics"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ runtime and per-task metrics.
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.2.0", default-features = false }
+tokio-metrics = { version = "0.2.1", default-features = false }
 ```
 
 ## Getting Started With Task Metrics
@@ -157,7 +157,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.2.0"
+tokio-metrics = "0.2.1"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of


### PR DESCRIPTION
# 0.2.1 (April 5th, 2023)

### Added
- task: add short and long delay metrics ([#44])

[#44]: https://github.com/tokio-rs/tokio-metrics/pull/44