### PR TITLE
Expose blocking_queue_depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ tokio::spawn(do_work());
   The maximum number of tasks currently scheduled any worker's local queue.
 - **[`min_local_queue_depth`]**  
   The minimum number of tasks currently scheduled any worker's local queue.
+- **[`blocking_queue_depth`]**
+  The number of tasks currently waiting to be executed in the blocking threadpool.
 - **[`elapsed`]**  
   Total amount of time elapsed since observing runtime metrics.
 - **[`budget_forced_yield_count`]**

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1021,6 +1021,12 @@ pub struct RuntimeMetrics {
     /// - [`RuntimeMetrics::max_local_queue_depth`]
     pub min_local_queue_depth: usize,
 
+    /// The number of tasks currently waiting to be executed in the runtime's blocking threadpool.
+    ///
+    /// ##### Definition
+    /// This metric is derived from [`tokio::runtime::RuntimeMetrics::blocking_queue_depth`].
+    pub blocking_queue_depth: usize,
+
     /// Total amount of time elapsed since observing runtime metrics.
     pub elapsed: Duration,
 
@@ -1273,7 +1279,6 @@ impl Worker {
         );
 
         // Local scheduled tasks is an absolute value
-
         let local_scheduled_tasks = rt.worker_local_queue_depth(self.worker);
         metrics.total_local_queue_depth += local_scheduled_tasks;
 
@@ -1284,6 +1289,9 @@ impl Worker {
         if local_scheduled_tasks < metrics.min_local_queue_depth {
             metrics.min_local_queue_depth = local_scheduled_tasks;
         }
+
+        // Blocking queue depth is an absolute value too
+        metrics.blocking_queue_depth = rt.blocking_queue_depth();
     }
 }
 


### PR DESCRIPTION
The worker queue depth is exposed but not the blocking queue. That one would be useful too!