### PR TITLE
support tokio 1.33 without stats feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rt = ["tokio"]
 tokio-stream = "0.1.11"
 futures-util = "0.3.19"
 pin-project-lite = "0.2.7"
-tokio = { version = "1.31.0", features = ["rt", "stats", "time", "net"], optional = true }
+tokio = { version = "1.31.0", features = ["rt", "time", "net"], optional = true }
 
 [dev-dependencies]
 axum = "0.6"


### PR DESCRIPTION
Tokio 1.33 has removed the `stats` feature, which apparently was unused for quite a bit.

I'm not sure how this repo manages releases, so feel free to consider this PR as an issue if you'd rather approach the problem differently. Thanks!