### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.3.1 (October 12th, 2023)
+
+### Fixed
+- task: fix doc error in idle definition ([#54])
+- chore: support tokio 1.33 without stats feature ([#55])
+
+[#54]: https://github.com/tokio-rs/tokio-metrics/pull/54
+[#55]: https://github.com/tokio-rs/tokio-metrics/pull/55
+
 # 0.3.0 (August 14th, 2023)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-metrics"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.56.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ runtime and per-task metrics.
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.3.0", default-features = false }
+tokio-metrics = { version = "0.3.1", default-features = false }
 ```
 
 ## Getting Started With Task Metrics
@@ -157,7 +157,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.2.2"
+tokio-metrics = "0.3.1"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of


### PR DESCRIPTION
# 0.3.1 (October 12th, 2023)

### Fixed
- task: fix doc error in idle definition ([#54])
- chore: support tokio 1.33 without stats feature ([#55])

[#54]: https://github.com/tokio-rs/tokio-metrics/pull/54
[#55]: https://github.com/tokio-rs/tokio-metrics/pull/55