### PR TITLE
chore: prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.4.0 (November 26th, 2024)
+
+The core Tokio crate has renamed some of the metrics and this breaking release
+uses the new names. The minimum required Tokio is bumped to 1.41, and the MSRV
+is bumped to 1.70 to match.
+
+- runtime: use new names for poll time histogram ([#66])
+- runtime: rename injection queue to global queue ([#66])
+- doc: various doc fixes ([#66], [#65])
+
+[#65]: https://github.com/tokio-rs/tokio-metrics/pull/65
+[#66]: https://github.com/tokio-rs/tokio-metrics/pull/66
+
 # 0.3.1 (October 12th, 2023)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-metrics"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.70.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ runtime and per-task metrics.
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.3.1", default-features = false }
+tokio-metrics = { version = "0.4.0", default-features = false }
 ```
 
 ## Getting Started With Task Metrics
@@ -157,7 +157,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.3.1"
+tokio-metrics = "0.4.0"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of


### PR DESCRIPTION
# 0.4.0 (November 26th, 2024)

The core Tokio crate has renamed some of the metrics and this breaking release uses the new names. The minimum required Tokio is bumped to 1.41, and the MSRV is bumped to 1.70 to match.

- runtime: use new names for poll time histogram ([#66])
- runtime: rename injection queue to global queue ([#66])
- doc: various doc fixes ([#66], [#65])

[#65]: https://github.com/tokio-rs/tokio-metrics/pull/65
[#66]: https://github.com/tokio-rs/tokio-metrics/pull/66