### PR TITLE
chore: prepare 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.4.1 (April 20th, 2025)
+
+### Added
+ - rt: add support for `blocking_queue_depth`, `live_task_count`, `blocking_threads_count`,
+   `idle_blocking_threads_count` ([#49], [#74])
+ - rt: add integration with metrics.rs ([#68])
+
+[#49]: https://github.com/tokio-rs/tokio-metrics/pull/49
+[#68]: https://github.com/tokio-rs/tokio-metrics/pull/68
+[#74]: https://github.com/tokio-rs/tokio-metrics/pull/74
+
 # 0.4.0 (November 26th, 2024)
 
 The core Tokio crate has renamed some of the metrics and this breaking release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-metrics"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.70.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ runtime and per-task metrics.
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.4.0", default-features = false }
+tokio-metrics = { version = "0.4.1", default-features = false }
 ```
 
 ## Getting Started With Task Metrics
@@ -157,7 +157,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.4.0"
+tokio-metrics = "0.4.1"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of


### PR DESCRIPTION
# 0.4.1 (April 20th, 2025)

### Added
 - rt: add support for `blocking_queue_depth`, `live_task_count`, `blocking_threads_count`,
   `idle_blocking_threads_count` ([#49], [#74])
 - rt: add integration with metrics.rs ([#68])

[#49]: https://github.com/tokio-rs/tokio-metrics/pull/49
[#68]: https://github.com/tokio-rs/tokio-metrics/pull/68
[#74]: https://github.com/tokio-rs/tokio-metrics/pull/74