### PR TITLE
fix: rt: in docs.rs, annotate the module as requiring `metrics-rs-integration` along with `rt` and `tokio_unstable`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+## How to test docs.rs changes
+
+Set up your local docs.rs environment as per official README:  
+https://github.com/rust-lang/docs.rs?tab=readme-ov-file#getting-started
+
+Make sure you have:
+- Your .env contents exported
+- docker-compose for db and s3 running
+- The web server running via local (or pure docker-compose approach)
+- If on a remote machine, port 3000 (or whatever your webserver is listening on) forwarded
+
+Invoke the build command against your local path:
+
+```
+# you could also point to the `cratesfyi` binary from outside of the docker workspace,
+# though you'll still need the right ENVs exported
+cargo run -- build crate --local ../tokio-metrics
+```
+
+View the generated documentation for `tokio-metrics` in your browser

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,14 @@ cfg_rt! {
         RuntimeMetrics,
         RuntimeMonitor,
     };
-    #[cfg(feature = "metrics-rs-integration")]
-    pub use runtime::metrics_rs_integration::{RuntimeMetricsReporterBuilder, RuntimeMetricsReporter};
 }
+
+#[cfg(all(tokio_unstable, feature = "rt", feature = "metrics-rs-integration"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(tokio_unstable, feature = "rt", feature = "metrics-rs-integration")))
+)]
+pub use runtime::metrics_rs_integration::{RuntimeMetricsReporter, RuntimeMetricsReporterBuilder};
 
 mod task;
 pub use task::{Instrumented, TaskMetrics, TaskMonitor};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,8 +4,6 @@ use tokio::runtime;
 #[cfg(feature = "metrics-rs-integration")]
 pub(crate) mod metrics_rs_integration;
 
-#[cfg(any(docsrs, all(tokio_unstable, feature = "rt")))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
 /// Monitors key metrics of the tokio runtime.
 ///
 /// ### Usage
@@ -53,8 +51,6 @@ pub struct RuntimeMonitor {
     runtime: runtime::RuntimeMetrics,
 }
 
-#[cfg(any(docsrs, all(tokio_unstable, feature = "rt")))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
 /// Key runtime metrics.
 #[non_exhaustive]
 #[derive(Default, Debug, Clone)]


### PR DESCRIPTION
Still need to test locally - just was getting the PR open before closing up for the day :)