### PR TITLE
Partially stablize runtime metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rt = ["tokio"]
 tokio-stream = "0.1.11"
 futures-util = "0.3.19"
 pin-project-lite = "0.2.7"
-tokio = { version = "1.41.0", features = ["rt", "time", "net"], optional = true }
+tokio = { version = "1.45.1", features = ["rt", "time", "net"], optional = true }
 metrics = { version = "0.24", optional = true }
 
 [dev-dependencies]
@@ -36,7 +36,7 @@ futures = "0.3.21"
 num_cpus = "1.13.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
-tokio = { version = "1.41.0", features = ["full", "rt", "time", "macros", "test-util"] }
+tokio = { version = "1.45.1", features = ["full", "rt", "time", "macros", "test-util"] }
 metrics-util = { version = "0.19", features = ["debugging"] }
 metrics = { version = "0.24" }
 metrics-exporter-prometheus = { version = "0.16", features = ["uds-listener"] }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ loop {
 
 ## Getting Started With Runtime Metrics
 
-This unstable functionality requires `tokio_unstable`, and the  `rt` crate
+Not all runtime metrics are stable. Using unstable metrics requires `tokio_unstable`, and the  `rt` crate
 feature. To enable `tokio_unstable`, the `--cfg` `tokio_unstable` must be passed
 to `rustc` when compiling. You can do this by setting the `RUSTFLAGS`
 environment variable before compiling your application; e.g.:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,11 @@
 //! ```
 
 #![cfg_attr(
-    all(tokio_unstable, feature = "rt"),
+    feature = "rt",
     doc = r##"
-### Monitoring runtime metrics (unstable)
+### Monitoring runtime metrics
 [Monitor][RuntimeMonitor] key [metrics][RuntimeMetrics] of a tokio runtime.
-**This functionality requires `tokio_unstable` and the crate feature `rt`.**
+**This functionality requires crate feature `rt` and some metrics require `tokio_unstable`.**
 
 In the below example, a [`RuntimeMonitor`] is [constructed][RuntimeMonitor::new] and
 three tasks are spawned and awaited; meanwhile, a fourth task prints [metrics][RuntimeMetrics]
@@ -104,7 +104,7 @@ async fn do_work() {
 }
 ```
 
-### Monitoring and publishing runtime metrics (unstable)
+### Monitoring and publishing runtime metrics
 
 If the `metrics-rs-integration` feature is additionally enabled, this crate allows
 publishing runtime metrics externally via [metrics-rs](metrics) exporters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,10 +172,10 @@ cfg_rt! {
     };
 }
 
-#[cfg(all(tokio_unstable, feature = "rt", feature = "metrics-rs-integration"))]
+#[cfg(all(feature = "rt", feature = "metrics-rs-integration"))]
 #[cfg_attr(
     docsrs,
-    doc(cfg(all(tokio_unstable, feature = "rt", feature = "metrics-rs-integration")))
+    doc(cfg(all(feature = "rt", feature = "metrics-rs-integration")))
 )]
 pub use runtime::metrics_rs_integration::{RuntimeMetricsReporter, RuntimeMetricsReporterBuilder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,8 @@ async fn main() {
 macro_rules! cfg_rt {
     ($($item:item)*) => {
         $(
-            #[cfg(all(tokio_unstable, feature = "rt"))]
-            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
+            #[cfg(all(feature = "rt"))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = "rt"))))]
             $item
         )*
     };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1007,6 +1007,7 @@ pub struct RuntimeMetrics {
     /// let mut next_interval = || intervals.next().unwrap();
     ///
     /// let interval = next_interval(); // end of interval 1
+    /// # #[cfg(tokio_unstable)]
     /// assert_eq!(interval.num_remote_schedules, 0);
     ///
     /// // spawn a system thread outside of the runtime
@@ -1020,6 +1021,7 @@ pub struct RuntimeMetrics {
     /// drop(runtime);
     ///
     /// let interval = next_interval(); // end of interval 2
+    /// # #[cfg(tokio_unstable)]
     /// assert_eq!(interval.num_remote_schedules, 2);
     /// # }
     /// ```

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -195,6 +195,7 @@ pub struct RuntimeMetrics {
     ///     println!("mean task poll duration is {:?}", interval.mean_poll_duration);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub mean_poll_duration: Duration,
 
     /// The average duration of a single invocation of poll on a task on the
@@ -216,6 +217,7 @@ pub struct RuntimeMetrics {
     ///     println!("min mean task poll duration is {:?}", interval.mean_poll_duration_worker_min);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub mean_poll_duration_worker_min: Duration,
 
     /// The average duration of a single invocation of poll on a task on the
@@ -237,6 +239,7 @@ pub struct RuntimeMetrics {
     ///     println!("max mean task poll duration is {:?}", interval.mean_poll_duration_worker_max);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub mean_poll_duration_worker_max: Duration,
 
     /// A histogram of task polls since the previous probe grouped by poll
@@ -271,6 +274,7 @@ pub struct RuntimeMetrics {
     ///     println!("poll count histogram {:?}", interval.poll_time_histogram);
     /// });
     /// ```
+    #[cfg(tokio_unstable)]
     pub poll_time_histogram: Vec<u64>,
 
     /// The number of times worker threads unparked but performed no work before parking again.
@@ -323,6 +327,7 @@ pub struct RuntimeMetrics {
     ///     assert!(next_interval().total_noop_count > 0);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_noop_count: u64,
 
     /// The maximum number of times any worker thread unparked but performed no work before parking
@@ -335,6 +340,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_noop_count`]
     /// - [`RuntimeMetrics::min_noop_count`]
+    #[cfg(tokio_unstable)]
     pub max_noop_count: u64,
 
     /// The minimum number of times any worker thread unparked but performed no work before parking
@@ -347,6 +353,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_noop_count`]
     /// - [`RuntimeMetrics::max_noop_count`]
+    #[cfg(tokio_unstable)]
     pub min_noop_count: u64,
 
     /// The number of tasks worker threads stole from another worker thread.
@@ -411,6 +418,7 @@ pub struct RuntimeMetrics {
     ///     let _ = tokio::time::sleep(std::time::Duration::ZERO).await;
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_steal_count: u64,
 
     /// The maximum number of tasks any worker thread stole from another worker thread.
@@ -422,6 +430,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_steal_count`]
     /// - [`RuntimeMetrics::min_steal_count`]
+    #[cfg(tokio_unstable)]
     pub max_steal_count: u64,
 
     /// The minimum number of tasks any worker thread stole from another worker thread.
@@ -433,6 +442,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_steal_count`]
     /// - [`RuntimeMetrics::max_steal_count`]
+    #[cfg(tokio_unstable)]
     pub min_steal_count: u64,
 
     /// The number of times worker threads stole tasks from another worker thread.
@@ -496,6 +506,7 @@ pub struct RuntimeMetrics {
     ///     let _ = tokio::time::sleep(std::time::Duration::ZERO).await;
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_steal_operations: u64,
 
     /// The maximum number of times any worker thread stole tasks from another worker thread.
@@ -507,6 +518,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_steal_operations`]
     /// - [`RuntimeMetrics::min_steal_operations`]
+    #[cfg(tokio_unstable)]
     pub max_steal_operations: u64,
 
     /// The minimum number of times any worker thread stole tasks from another worker thread.
@@ -518,6 +530,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_steal_operations`]
     /// - [`RuntimeMetrics::max_steal_operations`]
+    #[cfg(tokio_unstable)]
     pub min_steal_operations: u64,
 
     /// The number of tasks scheduled from **outside** of the runtime.
@@ -559,6 +572,7 @@ pub struct RuntimeMetrics {
     ///     assert_eq!(interval.num_remote_schedules, 0);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub num_remote_schedules: u64,
 
     /// The number of tasks scheduled from worker threads.
@@ -652,6 +666,7 @@ pub struct RuntimeMetrics {
     ///     let _ = tokio::time::sleep(std::time::Duration::ZERO).await;
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_local_schedule_count: u64,
 
     /// The maximum number of tasks scheduled from any one worker thread.
@@ -663,6 +678,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_local_schedule_count`]
     /// - [`RuntimeMetrics::min_local_schedule_count`]
+    #[cfg(tokio_unstable)]
     pub max_local_schedule_count: u64,
 
     /// The minimum number of tasks scheduled from any one worker thread.
@@ -674,6 +690,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_local_schedule_count`]
     /// - [`RuntimeMetrics::max_local_schedule_count`]
+    #[cfg(tokio_unstable)]
     pub min_local_schedule_count: u64,
 
     /// The number of times worker threads saturated their local queues.
@@ -723,6 +740,7 @@ pub struct RuntimeMetrics {
     ///     let _ = tokio::time::sleep(std::time::Duration::from_millis(1)).await;
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_overflow_count: u64,
 
     /// The maximum number of times any one worker saturated its local queue.
@@ -734,6 +752,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_overflow_count`]
     /// - [`RuntimeMetrics::min_overflow_count`]
+    #[cfg(tokio_unstable)]
     pub max_overflow_count: u64,
 
     /// The minimum number of times any one worker saturated its local queue.
@@ -745,6 +764,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_overflow_count`]
     /// - [`RuntimeMetrics::max_overflow_count`]
+    #[cfg(tokio_unstable)]
     pub min_overflow_count: u64,
 
     /// The number of tasks that have been polled across all worker threads.
@@ -790,6 +810,7 @@ pub struct RuntimeMetrics {
     ///     let _ = tokio::task::yield_now().await;
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_polls_count: u64,
 
     /// The maximum number of tasks that have been polled in any worker thread.
@@ -801,6 +822,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_polls_count`]
     /// - [`RuntimeMetrics::min_polls_count`]
+    #[cfg(tokio_unstable)]
     pub max_polls_count: u64,
 
     /// The minimum number of tasks that have been polled in any worker thread.
@@ -812,6 +834,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_polls_count`]
     /// - [`RuntimeMetrics::max_polls_count`]
+    #[cfg(tokio_unstable)]
     pub min_polls_count: u64,
 
     /// The amount of time worker threads were busy.
@@ -1084,6 +1107,7 @@ pub struct RuntimeMetrics {
     ///     SPINLOCK_B.store(false, Ordering::SeqCst);
     /// }
     /// ```
+    #[cfg(tokio_unstable)]
     pub total_local_queue_depth: usize,
 
     /// The maximum number of tasks currently scheduled any worker's local queue.
@@ -1095,6 +1119,7 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_local_queue_depth`]
     /// - [`RuntimeMetrics::min_local_queue_depth`]
+    #[cfg(tokio_unstable)]
     pub max_local_queue_depth: usize,
 
     /// The minimum number of tasks currently scheduled any worker's local queue.
@@ -1106,30 +1131,35 @@ pub struct RuntimeMetrics {
     /// ##### See also
     /// - [`RuntimeMetrics::total_local_queue_depth`]
     /// - [`RuntimeMetrics::max_local_queue_depth`]
+    #[cfg(tokio_unstable)]
     pub min_local_queue_depth: usize,
 
     /// The number of tasks currently waiting to be executed in the runtime's blocking threadpool.
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::blocking_queue_depth`].
+    #[cfg(tokio_unstable)]
     pub blocking_queue_depth: usize,
 
     /// The current number of alive tasks in the runtime.
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::num_alive_tasks`].
+    #[cfg(tokio_unstable)]
     pub live_tasks_count: usize,
 
     /// The number of additional threads spawned by the runtime.
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::num_blocking_threads`].
+    #[cfg(tokio_unstable)]
     pub blocking_threads_count: usize,
 
     /// The number of idle threads, which have spawned by the runtime for `spawn_blocking` calls.
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::num_idle_blocking_threads`].
+    #[cfg(tokio_unstable)]
     pub idle_blocking_threads_count: usize,
 
     /// Total amount of time elapsed since observing runtime metrics.
@@ -1143,12 +1173,14 @@ pub struct RuntimeMetrics {
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::budget_forced_yield_count`].
+    #[cfg(tokio_unstable)]
     pub budget_forced_yield_count: u64,
 
     /// Returns the number of ready events processed by the runtime’s I/O driver.
     ///
     /// ##### Definition
     /// This metric is derived from [`tokio::runtime::RuntimeMetrics::io_driver_ready_count`].
+    #[cfg(tokio_unstable)]
     pub io_driver_ready_count: u64,
 }
 
@@ -1157,13 +1189,20 @@ pub struct RuntimeMetrics {
 struct Worker {
     worker: usize,
     total_park_count: u64,
+    #[cfg(tokio_unstable)]
     total_noop_count: u64,
+    #[cfg(tokio_unstable)]
     total_steal_count: u64,
+    #[cfg(tokio_unstable)]
     total_steal_operations: u64,
+    #[cfg(tokio_unstable)]
     total_local_schedule_count: u64,
+    #[cfg(tokio_unstable)]
     total_overflow_count: u64,
+    #[cfg(tokio_unstable)]
     total_polls_count: u64,
     total_busy_duration: Duration,
+    #[cfg(tokio_unstable)]
     poll_time_histogram: Vec<u64>,
 }
 
@@ -1177,8 +1216,11 @@ pub struct RuntimeIntervals {
     workers: Vec<Worker>,
 
     // Number of tasks scheduled from *outside* of the runtime
+    #[cfg(tokio_unstable)]
     num_remote_schedules: u64,
+    #[cfg(tokio_unstable)]
     budget_forced_yield_count: u64,
+    #[cfg(tokio_unstable)]
     io_driver_ready_count: u64,
 }
 
@@ -1186,44 +1228,64 @@ impl RuntimeIntervals {
     fn probe(&mut self) -> RuntimeMetrics {
         let now = Instant::now();
 
+        #[cfg(tokio_unstable)]
         let num_remote_schedules = self.runtime.remote_schedule_count();
+        #[cfg(tokio_unstable)]
         let budget_forced_yields = self.runtime.budget_forced_yield_count();
+        #[cfg(tokio_unstable)]
         let io_driver_ready_events = self.runtime.io_driver_ready_count();
 
         let mut metrics = RuntimeMetrics {
             workers_count: self.runtime.num_workers(),
             elapsed: now - self.started_at,
             global_queue_depth: self.runtime.global_queue_depth(),
+            #[cfg(tokio_unstable)]
             num_remote_schedules: num_remote_schedules - self.num_remote_schedules,
             min_park_count: u64::MAX,
+            #[cfg(tokio_unstable)]
             min_noop_count: u64::MAX,
+            #[cfg(tokio_unstable)]
             min_steal_count: u64::MAX,
+            #[cfg(tokio_unstable)]
             min_local_schedule_count: u64::MAX,
+            #[cfg(tokio_unstable)]
             min_overflow_count: u64::MAX,
+            #[cfg(tokio_unstable)]
             min_polls_count: u64::MAX,
             min_busy_duration: Duration::from_secs(1000000000),
+            #[cfg(tokio_unstable)]
             min_local_queue_depth: usize::MAX,
+            #[cfg(tokio_unstable)]
             mean_poll_duration_worker_min: Duration::MAX,
+            #[cfg(tokio_unstable)]
             poll_time_histogram: vec![0; self.runtime.poll_time_histogram_num_buckets()],
+            #[cfg(tokio_unstable)]
             budget_forced_yield_count: budget_forced_yields - self.budget_forced_yield_count,
+            #[cfg(tokio_unstable)]
             io_driver_ready_count: io_driver_ready_events - self.io_driver_ready_count,
             ..Default::default()
         };
 
-        self.num_remote_schedules = num_remote_schedules;
+        #[cfg(tokio_unstable)]
+        {
+            self.num_remote_schedules = num_remote_schedules;
+            self.budget_forced_yield_count = budget_forced_yields;
+            self.io_driver_ready_count = io_driver_ready_events;
+        }
         self.started_at = now;
-        self.budget_forced_yield_count = budget_forced_yields;
-        self.io_driver_ready_count = io_driver_ready_events;
 
         for worker in &mut self.workers {
             worker.probe(&self.runtime, &mut metrics);
         }
 
-        if metrics.total_polls_count == 0 {
-            debug_assert_eq!(metrics.mean_poll_duration, Duration::default());
+        #[cfg(tokio_unstable)]
+        {
+            if metrics.total_polls_count == 0 {
+                debug_assert_eq!(metrics.mean_poll_duration, Duration::default());
 
-            metrics.mean_poll_duration_worker_max = Duration::default();
-            metrics.mean_poll_duration_worker_min = Duration::default();
+                metrics.mean_poll_duration_worker_max = Duration::default();
+                metrics.mean_poll_duration_worker_min = Duration::default();
+            }
         }
 
         metrics
@@ -1304,8 +1366,12 @@ impl RuntimeMonitor {
             runtime: self.runtime.clone(),
             started_at,
             workers,
+
+            #[cfg(tokio_unstable)]
             num_remote_schedules: self.runtime.remote_schedule_count(),
+            #[cfg(tokio_unstable)]
             budget_forced_yield_count: self.runtime.budget_forced_yield_count(),
+            #[cfg(tokio_unstable)]
             io_driver_ready_count: self.runtime.io_driver_ready_count(),
         }
     }
@@ -1313,6 +1379,7 @@ impl RuntimeMonitor {
 
 impl Worker {
     fn new(worker: usize, rt: &runtime::RuntimeMetrics) -> Worker {
+        #[cfg(tokio_unstable)]
         let poll_time_histogram = if rt.poll_time_histogram_enabled() {
             vec![0; rt.poll_time_histogram_num_buckets()]
         } else {
@@ -1322,13 +1389,20 @@ impl Worker {
         Worker {
             worker,
             total_park_count: rt.worker_park_count(worker),
+            #[cfg(tokio_unstable)]
             total_noop_count: rt.worker_noop_count(worker),
+            #[cfg(tokio_unstable)]
             total_steal_count: rt.worker_steal_count(worker),
+            #[cfg(tokio_unstable)]
             total_steal_operations: rt.worker_steal_operations(worker),
+            #[cfg(tokio_unstable)]
             total_local_schedule_count: rt.worker_local_schedule_count(worker),
+            #[cfg(tokio_unstable)]
             total_overflow_count: rt.worker_overflow_count(worker),
+            #[cfg(tokio_unstable)]
             total_polls_count: rt.worker_poll_count(worker),
             total_busy_duration: rt.worker_total_busy_duration(worker),
+            #[cfg(tokio_unstable)]
             poll_time_histogram,
         }
     }
@@ -1352,7 +1426,9 @@ impl Worker {
             }};
         }
 
+        #[cfg(tokio_unstable)]
         let mut worker_polls_count = self.total_polls_count;
+        #[cfg(tokio_unstable)]
         let total_polls_count = metrics.total_polls_count;
 
         metric!(
@@ -1361,42 +1437,45 @@ impl Worker {
             min_park_count,
             worker_park_count
         );
-        metric!(
-            total_noop_count,
-            max_noop_count,
-            min_noop_count,
-            worker_noop_count
-        );
-        metric!(
-            total_steal_count,
-            max_steal_count,
-            min_steal_count,
-            worker_steal_count
-        );
-        metric!(
-            total_steal_operations,
-            max_steal_operations,
-            min_steal_operations,
-            worker_steal_operations
-        );
-        metric!(
-            total_local_schedule_count,
-            max_local_schedule_count,
-            min_local_schedule_count,
-            worker_local_schedule_count
-        );
-        metric!(
-            total_overflow_count,
-            max_overflow_count,
-            min_overflow_count,
-            worker_overflow_count
-        );
-        metric!(
-            total_polls_count,
-            max_polls_count,
-            min_polls_count,
-            worker_poll_count
-        );
+        #[cfg(tokio_unstable)]
+        {
+            metric!(
+                total_noop_count,
+                max_noop_count,
+                min_noop_count,
+                worker_noop_count
+            );
+            metric!(
+                total_steal_count,
+                max_steal_count,
+                min_steal_count,
+                worker_steal_count
+            );
+            metric!(
+                total_steal_operations,
+                max_steal_operations,
+                min_steal_operations,
+                worker_steal_operations
+            );
+            metric!(
+                total_local_schedule_count,
+                max_local_schedule_count,
+                min_local_schedule_count,
+                worker_local_schedule_count
+            );
+            metric!(
+                total_overflow_count,
+                max_overflow_count,
+                min_overflow_count,
+                worker_overflow_count
+            );
+            metric!(
+                total_polls_count,
+                max_polls_count,
+                min_polls_count,
+                worker_poll_count
+            );
+        }
         metric!(
             total_busy_duration,
             max_busy_duration,
@@ -1404,71 +1483,78 @@ impl Worker {
             worker_total_busy_duration
         );
 
-        // Get the number of polls since last probe
-        worker_polls_count = self.total_polls_count - worker_polls_count;
-
-        // Update the mean task poll duration if there were polls
-        if worker_polls_count > 0 {
-            let val = rt.worker_mean_poll_time(self.worker);
-
-            if val > metrics.mean_poll_duration_worker_max {
-                metrics.mean_poll_duration_worker_max = val;
-            }
-
-            if val < metrics.mean_poll_duration_worker_min {
-                metrics.mean_poll_duration_worker_min = val;
-            }
-
-            // First, scale the current value down
-            let ratio = total_polls_count as f64 / metrics.total_polls_count as f64;
-            let mut mean = metrics.mean_poll_duration.as_nanos() as f64 * ratio;
-
-            // Add the scaled current worker's mean poll duration
-            let ratio = worker_polls_count as f64 / metrics.total_polls_count as f64;
-            mean += val.as_nanos() as f64 * ratio;
-
-            metrics.mean_poll_duration = Duration::from_nanos(mean as u64);
-        }
-        
-        // Update the histogram counts if there were polls since last count
-        if worker_polls_count > 0 {
-            for (bucket, cell) in metrics.poll_time_histogram.iter_mut().enumerate() {
-                let new = rt.poll_time_histogram_bucket_count(self.worker, bucket);
-                let delta = new - self.poll_time_histogram[bucket];
-                self.poll_time_histogram[bucket] = new;
-
-                *cell += delta;
-            }
-        }
-
-        // Local scheduled tasks is an absolute value
-        let local_scheduled_tasks = rt.worker_local_queue_depth(self.worker);
-        metrics.total_local_queue_depth += local_scheduled_tasks;
-
-        if local_scheduled_tasks > metrics.max_local_queue_depth {
-            metrics.max_local_queue_depth = local_scheduled_tasks;
-        }
-
-        if local_scheduled_tasks < metrics.min_local_queue_depth {
-            metrics.min_local_queue_depth = local_scheduled_tasks;
-        }
-
-        // Blocking queue depth is an absolute value too
-        metrics.blocking_queue_depth = rt.blocking_queue_depth();
-
-        #[allow(deprecated)]
+        #[cfg(tokio_unstable)]
         {
-            // use the deprecated active_tasks_count here to support slightly older versions of Tokio,
-            // it's the same.
-            metrics.live_tasks_count = rt.active_tasks_count();
+            // Get the number of polls since last probe
+            worker_polls_count = self.total_polls_count - worker_polls_count;
+
+            // Update the mean task poll duration if there were polls
+            if worker_polls_count > 0 {
+                let val = rt.worker_mean_poll_time(self.worker);
+
+                if val > metrics.mean_poll_duration_worker_max {
+                    metrics.mean_poll_duration_worker_max = val;
+                }
+
+                if val < metrics.mean_poll_duration_worker_min {
+                    metrics.mean_poll_duration_worker_min = val;
+                }
+
+                // First, scale the current value down
+                let ratio = total_polls_count as f64 / metrics.total_polls_count as f64;
+                let mut mean = metrics.mean_poll_duration.as_nanos() as f64 * ratio;
+
+                // Add the scaled current worker's mean poll duration
+                let ratio = worker_polls_count as f64 / metrics.total_polls_count as f64;
+                mean += val.as_nanos() as f64 * ratio;
+
+                metrics.mean_poll_duration = Duration::from_nanos(mean as u64);
+            }
+
+            // Update the histogram counts if there were polls since last count
+            if worker_polls_count > 0 {
+                for (bucket, cell) in metrics.poll_time_histogram.iter_mut().enumerate() {
+                    let new = rt.poll_time_histogram_bucket_count(self.worker, bucket);
+                    let delta = new - self.poll_time_histogram[bucket];
+                    self.poll_time_histogram[bucket] = new;
+
+                    *cell += delta;
+                }
+            }
         }
-        metrics.blocking_threads_count = rt.num_blocking_threads();
-        metrics.idle_blocking_threads_count = rt.num_idle_blocking_threads();
+
+        #[cfg(tokio_unstable)]
+        {
+            // Local scheduled tasks is an absolute value
+            let local_scheduled_tasks = rt.worker_local_queue_depth(self.worker);
+            metrics.total_local_queue_depth += local_scheduled_tasks;
+
+            if local_scheduled_tasks > metrics.max_local_queue_depth {
+                metrics.max_local_queue_depth = local_scheduled_tasks;
+            }
+
+            if local_scheduled_tasks < metrics.min_local_queue_depth {
+                metrics.min_local_queue_depth = local_scheduled_tasks;
+            }
+
+            // Blocking queue depth is an absolute value too
+            metrics.blocking_queue_depth = rt.blocking_queue_depth();
+
+            #[allow(deprecated)]
+            {
+                // use the deprecated active_tasks_count here to support slightly older versions of Tokio,
+                // it's the same.
+                metrics.live_tasks_count = rt.active_tasks_count();
+            }
+            metrics.blocking_threads_count = rt.num_blocking_threads();
+            metrics.idle_blocking_threads_count = rt.num_idle_blocking_threads();
+        }
     }
 }
 
 impl RuntimeMetrics {
     /// Returns the ratio of the [`RuntimeMetrics::total_polls_count`] to the [`RuntimeMetrics::total_noop_count`].
+    #[cfg(tokio_unstable)]
     pub fn mean_polls_per_park(&self) -> f64 {
         let total_park_count = self.total_park_count - self.total_noop_count;
         if total_park_count == 0 {

--- a/src/runtime/metrics_rs_integration.rs
+++ b/src/runtime/metrics_rs_integration.rs
@@ -14,11 +14,11 @@ use super::{RuntimeIntervals, RuntimeMetrics, RuntimeMonitor};
 /// can use the [`with_metrics_transformer`] function to customize the metric names.
 ///
 /// ### Usage
-/// 
+///
 /// To upload metrics via [metrics-rs], you need to set up a reporter, which
 /// is actually what exports the metrics outside of the program. You must set
 /// up the reporter before you call [`describe_and_run`].
-/// 
+///
 /// You can find exporters within the [metrics-rs] docs. One such reporter
 /// is the [metrics_exporter_prometheus] reporter, which makes metrics visible
 /// through Prometheus.
@@ -53,7 +53,7 @@ use super::{RuntimeIntervals, RuntimeMetrics, RuntimeMonitor};
 ///     .unwrap();
 /// }
 /// ```
-/// 
+///
 /// [`describe_and_run`]: RuntimeMetricsReporterBuilder::describe_and_run
 /// [`with_metrics_transformer`]: RuntimeMetricsReporterBuilder::with_metrics_transformer
 /// [metrics-rs]: metrics
@@ -66,9 +66,9 @@ pub struct RuntimeMetricsReporterBuilder {
 impl fmt::Debug for RuntimeMetricsReporterBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RuntimeMetricsReporterBuilder")
-         .field("interval", &self.interval)
-         // skip metrics_transformer field
-         .finish()
+            .field("interval", &self.interval)
+            // skip metrics_transformer field
+            .finish()
     }
 }
 
@@ -105,7 +105,7 @@ impl RuntimeMetricsReporterBuilder {
     /// Set a custom "metrics transformer", which is used during `build` to transform the metric
     /// names into metric keys, for example to add dimensions. The string metric names used by this reporter
     /// all start with `tokio_`. The default transformer is just [`metrics::Key::from_static_name`]
-    /// 
+    ///
     /// For example, to attach a dimension named "application" with value "my_app", and to replace
     /// `tokio_` with `my_app_`
     /// ```
@@ -126,7 +126,10 @@ impl RuntimeMetricsReporterBuilder {
     ///     );
     /// }
     /// ```
-    pub fn with_metrics_transformer(mut self, transformer: impl FnMut(&'static str) -> metrics::Key + Send + 'static) -> Self {
+    pub fn with_metrics_transformer(
+        mut self,
+        transformer: impl FnMut(&'static str) -> metrics::Key + Send + 'static,
+    ) -> Self {
         self.metrics_transformer = Box::new(transformer);
         self
     }
@@ -134,7 +137,7 @@ impl RuntimeMetricsReporterBuilder {
     /// Build the [`RuntimeMetricsReporter`] for the current Tokio runtime. This function will capture
     /// the [`Counter`]s, [`Gauge`]s and [`Histogram`]s from the current [metrics-rs] reporter,
     /// so if you are using [`with_local_recorder`], you should wrap this function and [`describe`] with it.
-    /// 
+    ///
     /// For example:
     /// ```
     /// # use std::sync::Arc;
@@ -144,7 +147,7 @@ impl RuntimeMetricsReporterBuilder {
     ///     let builder = tokio_metrics::RuntimeMetricsReporterBuilder::default();
     ///     let recorder = Arc::new(metrics_util::debugging::DebuggingRecorder::new());
     ///     let metrics_reporter = metrics::with_local_recorder(&recorder, || builder.describe().build());
-    /// 
+    ///
     ///     // no need to wrap `run()`, since the metrics are already captured
     ///     tokio::task::spawn(metrics_reporter.run());
     /// }
@@ -166,7 +169,7 @@ impl RuntimeMetricsReporterBuilder {
     /// the [`Counter`]s, [`Gauge`]s and [`Histogram`]s from the current [metrics-rs] reporter,
     /// so if you are using [`with_local_recorder`], you should wrap this function and [`describe`]
     /// with it.
-    /// 
+    ///
     /// [`Counter`]: metrics::Counter
     /// [`Gauge`]: metrics::Counter
     /// [`Histogram`]: metrics::Counter
@@ -188,7 +191,7 @@ impl RuntimeMetricsReporterBuilder {
     /// which makes them easier to use. However, some reporters don't support
     /// describing the same metric name more than once, so it is generally a good
     /// idea to only call this function once per metric reporter.
-    /// 
+    ///
     /// [`describe_counter`]: metrics::describe_counter
     /// [metrics-rs]: metrics
     pub fn describe(mut self) -> Self {
@@ -203,13 +206,13 @@ impl RuntimeMetricsReporterBuilder {
     /// describing the same metric name more than once. If you are emitting multiple
     /// metrics via a single reporter, try to call [`describe`] once and [`run`] for each
     /// runtime metrics reporter.
-    /// 
+    ///
     /// ### Working with a custom reporter
     ///
     /// If you want to set a local metrics reporter, you shouldn't be calling this method,
     /// but you should instead call `.describe().build()` within [`with_local_recorder`] and then
     /// call `run` (see the docs on [`build`]).
-    /// 
+    ///
     /// [describing]: Self::describe
     /// [`describe`]: Self::describe
     /// [`build`]: Self::build.
@@ -243,47 +246,61 @@ pub struct RuntimeMetricsReporter {
 }
 
 macro_rules! kind_to_type {
-    (Counter) => (metrics::Counter);
-    (Gauge) => (metrics::Gauge);
-    (Histogram) => (metrics::Histogram);
+    (Counter) => {
+        metrics::Counter
+    };
+    (Gauge) => {
+        metrics::Gauge
+    };
+    (Histogram) => {
+        metrics::Histogram
+    };
 }
 
 macro_rules! metric_key {
-    ($transform_fn:ident, $name:ident) => ($transform_fn(concat!("tokio_", stringify!($name))))
+    ($transform_fn:ident, $name:ident) => {
+        $transform_fn(concat!("tokio_", stringify!($name)))
+    };
 }
 
 // calling `trim` since /// inserts spaces into docs
 macro_rules! describe_metric_ref {
-    ($transform_fn:ident, $doc:expr, $name:ident: Counter<$unit:ident> []) => (
-        metrics::describe_counter!(metric_key!($transform_fn, $name).name().to_owned(), metrics::Unit::$unit, $doc.trim())
-    );
-    ($transform_fn:ident, $doc:expr, $name:ident: Gauge<$unit:ident> []) => (
-        metrics::describe_gauge!(metric_key!($transform_fn, $name).name().to_owned(), metrics::Unit::$unit, $doc.trim())
-    );
-    ($transform_fn:ident, $doc:expr, $name:ident: Histogram<$unit:ident> []) => (
-        metrics::describe_histogram!(metric_key!($transform_fn, $name).name().to_owned(), metrics::Unit::$unit, $doc.trim())
-    );
+    ($transform_fn:ident, $doc:expr, $name:ident: Counter<$unit:ident> []) => {
+        metrics::describe_counter!(
+            metric_key!($transform_fn, $name).name().to_owned(),
+            metrics::Unit::$unit,
+            $doc.trim()
+        )
+    };
+    ($transform_fn:ident, $doc:expr, $name:ident: Gauge<$unit:ident> []) => {
+        metrics::describe_gauge!(
+            metric_key!($transform_fn, $name).name().to_owned(),
+            metrics::Unit::$unit,
+            $doc.trim()
+        )
+    };
+    ($transform_fn:ident, $doc:expr, $name:ident: Histogram<$unit:ident> []) => {
+        metrics::describe_histogram!(
+            metric_key!($transform_fn, $name).name().to_owned(),
+            metrics::Unit::$unit,
+            $doc.trim()
+        )
+    };
 }
 
 macro_rules! capture_metric_ref {
-    ($transform_fn:ident, $name:ident: Counter []) => (
-        {
-            let (name, labels) = metric_key!($transform_fn, $name).into_parts();
-            metrics::counter!(name, labels)
-        }
-    );
-    ($transform_fn:ident, $name:ident: Gauge []) => (
-        {
-            let (name, labels) = metric_key!($transform_fn, $name).into_parts();
-            metrics::gauge!(name, labels)
-        }
-    );
-    ($transform_fn:ident, $name:ident: Histogram []) => (
-        {
-            let (name, labels) = metric_key!($transform_fn, $name).into_parts();
-            metrics::histogram!(name, labels)
-        }
-    );
+    ($transform_fn:ident, $name:ident: Counter []) => {{
+        let (name, labels) = metric_key!($transform_fn, $name).into_parts();
+        metrics::counter!(name, labels)
+    }};
+    ($transform_fn:ident, $name:ident: Gauge []) => {{
+        let (name, labels) = metric_key!($transform_fn, $name).into_parts();
+        metrics::gauge!(name, labels)
+    }};
+    ($transform_fn:ident, $name:ident: Histogram []) => {{
+        let (name, labels) = metric_key!($transform_fn, $name).into_parts();
+        metrics::histogram!(name, labels)
+    }};
 }
 
 macro_rules! metric_refs {
@@ -291,13 +308,14 @@ macro_rules! metric_refs {
         [$struct_name:ident] [$($ignore:ident),* $(,)?] {
         $(
             #[doc = $doc:tt]
-            $name:ident: $kind:tt <$unit:ident> $opts:tt
+            $(@$unstable:ident)? $name:ident: $kind:tt <$unit:ident> $opts:tt
         ),*
         $(,)?
         }
   ) => {
         struct $struct_name {
             $(
+                $(#[cfg($unstable)])?
                 $name: kind_to_type!($kind)
             ),*
         }
@@ -306,6 +324,7 @@ macro_rules! metric_refs {
             fn capture(transform_fn: &mut dyn FnMut(&'static str) -> metrics::Key) -> Self {
                 Self {
                     $(
+                        $(#[cfg($unstable)])?
                         $name: capture_metric_ref!(transform_fn, $name: $kind $opts)
                     ),*
                 }
@@ -313,12 +332,14 @@ macro_rules! metric_refs {
 
             fn emit(&self, metrics: RuntimeMetrics, tokio: &tokio::runtime::RuntimeMetrics) {
                 $(
+                    $(#[cfg($unstable)])?
                     MyMetricOp::op((&self.$name, metrics.$name), tokio);
                 )*
             }
 
             fn describe(transform_fn: &mut dyn FnMut(&'static str) -> metrics::Key) {
                 $(
+                    $(#[cfg($unstable)])?
                     describe_metric_ref!(transform_fn, $doc, $name: $kind<$unit> $opts);
                 )*
             }
@@ -363,51 +384,51 @@ metric_refs! {
         /// The number of times worker threads parked
         total_park_count: Gauge<Count> [],
         /// The average duration of a single invocation of poll on a task
-        mean_poll_duration: Gauge<Microseconds> [],
+        @tokio_unstable mean_poll_duration: Gauge<Microseconds> [],
         /// The average duration of a single invocation of poll on a task on the worker with the lowest value
-        mean_poll_duration_worker_min: Gauge<Microseconds> [],
+        @tokio_unstable mean_poll_duration_worker_min: Gauge<Microseconds> [],
         /// The average duration of a single invocation of poll on a task on the worker with the highest value
-        mean_poll_duration_worker_max: Gauge<Microseconds> [],
+        @tokio_unstable mean_poll_duration_worker_max: Gauge<Microseconds> [],
         /// A histogram of task polls since the previous probe grouped by poll times
-        poll_time_histogram: Histogram<Microseconds> [],
+        @tokio_unstable poll_time_histogram: Histogram<Microseconds> [],
         /// The number of times worker threads unparked but performed no work before parking again
-        total_noop_count: Counter<Count> [],
+        @tokio_unstable total_noop_count: Counter<Count> [],
         /// The maximum number of times any worker thread unparked but performed no work before parking again
-        max_noop_count: Counter<Count> [],
+        @tokio_unstable max_noop_count: Counter<Count> [],
         /// The minimum number of times any worker thread unparked but performed no work before parking again
-        min_noop_count: Counter<Count> [],
+        @tokio_unstable min_noop_count: Counter<Count> [],
         /// The number of tasks worker threads stole from another worker thread
-        total_steal_count: Counter<Count> [],
+        @tokio_unstable total_steal_count: Counter<Count> [],
         /// The maximum number of tasks any worker thread stole from another worker thread.
-        max_steal_count: Counter<Count> [],
+        @tokio_unstable max_steal_count: Counter<Count> [],
         /// The minimum number of tasks any worker thread stole from another worker thread
-        min_steal_count: Counter<Count> [],
+        @tokio_unstable min_steal_count: Counter<Count> [],
         /// The number of times worker threads stole tasks from another worker thread
-        total_steal_operations: Counter<Count> [],
+        @tokio_unstable total_steal_operations: Counter<Count> [],
         /// The maximum number of times any worker thread stole tasks from another worker thread
-        max_steal_operations: Counter<Count> [],
+        @tokio_unstable max_steal_operations: Counter<Count> [],
         /// The minimum number of times any worker thread stole tasks from another worker thread
-        min_steal_operations: Counter<Count> [],
+        @tokio_unstable min_steal_operations: Counter<Count> [],
         /// The number of tasks scheduled from **outside** of the runtime
-        num_remote_schedules: Counter<Count> [],
+        @tokio_unstable num_remote_schedules: Counter<Count> [],
         /// The number of tasks scheduled from worker threads
-        total_local_schedule_count: Counter<Count> [],
+        @tokio_unstable total_local_schedule_count: Counter<Count> [],
         /// The maximum number of tasks scheduled from any one worker thread
-        max_local_schedule_count: Counter<Count> [],
+        @tokio_unstable max_local_schedule_count: Counter<Count> [],
         /// The minimum number of tasks scheduled from any one worker thread
-        min_local_schedule_count: Counter<Count> [],
+        @tokio_unstable min_local_schedule_count: Counter<Count> [],
         /// The number of times worker threads saturated their local queues
-        total_overflow_count: Counter<Count> [],
+        @tokio_unstable total_overflow_count: Counter<Count> [],
         /// The maximum number of times any one worker saturated its local queue
-        max_overflow_count: Counter<Count> [],
+        @tokio_unstable max_overflow_count: Counter<Count> [],
         /// The minimum number of times any one worker saturated its local queue
-        min_overflow_count: Counter<Count> [],
+        @tokio_unstable min_overflow_count: Counter<Count> [],
         /// The number of tasks that have been polled across all worker threads
-        total_polls_count: Counter<Count> [],
+        @tokio_unstable total_polls_count: Counter<Count> [],
         /// The maximum number of tasks that have been polled in any worker thread
-        max_polls_count: Counter<Count> [],
+        @tokio_unstable max_polls_count: Counter<Count> [],
         /// The minimum number of tasks that have been polled in any worker thread
-        min_polls_count: Counter<Count> [],
+        @tokio_unstable min_polls_count: Counter<Count> [],
         /// The amount of time worker threads were busy
         total_busy_duration: Counter<Microseconds> [],
         /// The maximum amount of time a worker thread was busy
@@ -417,23 +438,23 @@ metric_refs! {
         /// The number of tasks currently scheduled in the runtime's global queue
         global_queue_depth: Gauge<Count> [],
         /// The total number of tasks currently scheduled in workers' local queues
-        total_local_queue_depth: Gauge<Count> [],
+        @tokio_unstable total_local_queue_depth: Gauge<Count> [],
         /// The maximum number of tasks currently scheduled any worker's local queue
-        max_local_queue_depth: Gauge<Count> [],
+        @tokio_unstable max_local_queue_depth: Gauge<Count> [],
         /// The minimum number of tasks currently scheduled any worker's local queue
-        min_local_queue_depth: Gauge<Count> [],
+        @tokio_unstable min_local_queue_depth: Gauge<Count> [],
         /// The number of tasks currently waiting to be executed in the runtime's blocking threadpool.
-        blocking_queue_depth: Gauge<Count> [],
+        @tokio_unstable blocking_queue_depth: Gauge<Count> [],
         /// The current number of alive tasks in the runtime.
-        live_tasks_count: Gauge<Count> [],
+        @tokio_unstable live_tasks_count: Gauge<Count> [],
         /// The number of additional threads spawned by the runtime.
-        blocking_threads_count: Gauge<Count> [],
+        @tokio_unstable blocking_threads_count: Gauge<Count> [],
         /// The number of idle threads, which have spawned by the runtime for `spawn_blocking` calls.
-        idle_blocking_threads_count: Gauge<Count> [],
+        @tokio_unstable idle_blocking_threads_count: Gauge<Count> [],
         /// Returns the number of times that tasks have been forced to yield back to the scheduler after exhausting their task budgets
-        budget_forced_yield_count: Counter<Count> [],
+        @tokio_unstable budget_forced_yield_count: Counter<Count> [],
         /// Returns the number of ready events processed by the runtime’s I/O driver
-        io_driver_ready_count: Counter<Count> [],
+        @tokio_unstable io_driver_ready_count: Counter<Count> [],
     }
 }
 trait MyMetricOp {
@@ -442,7 +463,8 @@ trait MyMetricOp {
 
 impl MyMetricOp for (&metrics::Counter, Duration) {
     fn op(self, _tokio: &tokio::runtime::RuntimeMetrics) {
-        self.0.increment(self.1.as_micros().try_into().unwrap_or(u64::MAX));
+        self.0
+            .increment(self.1.as_micros().try_into().unwrap_or(u64::MAX));
     }
 }
 
@@ -470,6 +492,7 @@ impl MyMetricOp for (&metrics::Gauge, usize) {
     }
 }
 
+#[cfg(tokio_unstable)]
 impl MyMetricOp for (&metrics::Histogram, Vec<u64>) {
     fn op(self, tokio: &tokio::runtime::RuntimeMetrics) {
         for (i, bucket) in self.1.iter().enumerate() {
@@ -477,7 +500,8 @@ impl MyMetricOp for (&metrics::Histogram, Vec<u64>) {
             if *bucket > 0 {
                 // emit using range.start to avoid very large numbers for open bucket
                 // FIXME: do we want to do something else here?
-                self.0.record_many(range.start.as_micros() as f64, *bucket as usize);
+                self.0
+                    .record_many(range.start.as_micros() as f64, *bucket as usize);
             }
         }
     }
@@ -486,17 +510,19 @@ impl MyMetricOp for (&metrics::Histogram, Vec<u64>) {
 impl fmt::Debug for RuntimeMetricsReporter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RuntimeMetricsReporter")
-         .field("interval", &self.interval)
-         // skip intervals field
-         .finish()
+            .field("interval", &self.interval)
+            // skip intervals field
+            .finish()
     }
 }
 
-impl RuntimeMetricsReporter
-{
+impl RuntimeMetricsReporter {
     /// Collect and publish metrics once to the configured [metrics_rs](metrics) reporter.
     pub fn run_once(&mut self) {
-        let metrics = self.intervals.next().expect("RuntimeIntervals::next never returns None");
+        let metrics = self
+            .intervals
+            .next()
+            .expect("RuntimeIntervals::next never returns None");
         self.emitter.emit(metrics, &self.intervals.runtime);
     }
 


### PR DESCRIPTION
This PR partially stabilizes the runtime metrics feature.

As discussed in #86 , the approach is to stabilize `tokio_metrics::RuntimeMonitor` and the metrics that are considered stable in tokio while keeping unstable metrics opt-in behind the `tokio_unstable` config.

Also while reviewing, you might want to be aware that the [tokio docs](https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html) on docs.rs are incorrectly showing some metrics as stable when they are not. (See https://github.com/tokio-rs/tokio/issues/6745)

closes #86