### PR TITLE
make `live_tasks_count` (`num_alive_tasks()`) stable

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -150,6 +150,12 @@ define_runtime_metrics! {
         /// ```
         pub workers_count: usize,
 
+        /// The current number of alive tasks in the runtime.
+        ///
+        /// ##### Definition
+        /// This metric is derived from [`tokio::runtime::RuntimeMetrics::num_alive_tasks`].
+        pub live_tasks_count: usize,
+
         /// The number of times worker threads parked.
         ///
         /// The worker park count increases by one each time the worker parks the thread waiting for
@@ -1155,12 +1161,6 @@ define_runtime_metrics! {
         /// This metric is derived from [`tokio::runtime::RuntimeMetrics::blocking_queue_depth`].
         pub blocking_queue_depth: usize,
 
-        /// The current number of alive tasks in the runtime.
-        ///
-        /// ##### Definition
-        /// This metric is derived from [`tokio::runtime::RuntimeMetrics::num_alive_tasks`].
-        pub live_tasks_count: usize,
-
         /// The number of additional threads spawned by the runtime.
         ///
         /// ##### Definition
@@ -1267,6 +1267,7 @@ impl RuntimeIntervals {
 
         let mut metrics = RuntimeMetrics {
             workers_count: self.runtime.num_workers(),
+            live_tasks_count: self.runtime.num_alive_tasks(),
             elapsed: now - self.started_at,
             global_queue_depth: self.runtime.global_queue_depth(),
             min_park_count: u64::MAX,
@@ -1556,12 +1557,6 @@ impl Worker {
             // Blocking queue depth is an absolute value too
             metrics.blocking_queue_depth = rt.blocking_queue_depth();
 
-            #[allow(deprecated)]
-            {
-                // use the deprecated active_tasks_count here to support slightly older versions of Tokio,
-                // it's the same.
-                metrics.live_tasks_count = rt.active_tasks_count();
-            }
             metrics.blocking_threads_count = rt.num_blocking_threads();
             metrics.idle_blocking_threads_count = rt.num_idle_blocking_threads();
         }

--- a/src/runtime/metrics_rs_integration.rs
+++ b/src/runtime/metrics_rs_integration.rs
@@ -249,6 +249,8 @@ metric_refs! {
         stable {
             /// The number of worker threads used by the runtime
             workers_count: Gauge<Count> [],
+            /// The current number of alive tasks in the runtime.
+            live_tasks_count: Gauge<Count> [],
             /// The number of times worker threads parked
             max_park_count: Gauge<Count> [],
             /// The minimum number of times any worker thread parked
@@ -323,8 +325,6 @@ metric_refs! {
             min_local_queue_depth: Gauge<Count> [],
             /// The number of tasks currently waiting to be executed in the runtime's blocking threadpool.
             blocking_queue_depth: Gauge<Count> [],
-            /// The current number of alive tasks in the runtime.
-            live_tasks_count: Gauge<Count> [],
             /// The number of additional threads spawned by the runtime.
             blocking_threads_count: Gauge<Count> [],
             /// The number of idle threads, which have spawned by the runtime for `spawn_blocking` calls.


### PR DESCRIPTION
https://docs.rs/tokio/1.45.1/tokio/runtime/struct.RuntimeMetrics.html#method.num_alive_tasks

context PR: https://github.com/tokio-rs/tokio-metrics/pull/87

It seems to have been stable at the time of #87, tokio=1.45.1, so I'm not sure why it was marked unstable. https://github.com/tokio-rs/tokio/issues/6745 doc bug doesn't seem to apply. Maybe it was overlooked after PR changes.