### PR TITLE
Add release workflow with release-plz and trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Publish release
+
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write # Required for OIDC token exchange / trusted publishing
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    if: github.repository_owner == 'tokio-rs'
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Authenticate to crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Run release-plz
+        uses: release-plz/action@v0.5.102
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,9 @@
+[workspace]
+git_release_enable = false
+changelog_update = false
+
+[[package]]
+name = "tokio-metrics"
+changelog_path = "./CHANGELOG.md"
+changelog_update = true
+git_release_enable = true


### PR DESCRIPTION
Before merging, I believe an owner needs to:

- Create a github environment called `release`

- Add a trusted publisher to crates.io with the workflow `release.yml` and environment `release`