### PR TITLE
feat: publicly export task `TaskIntervals` type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,4 +207,4 @@ mod task;
     doc(cfg(all(feature = "rt", feature = "metrics-rs-integration")))
 )]
 pub use task::metrics_rs_integration::{TaskMetricsReporter, TaskMetricsReporterBuilder};
-pub use task::{Instrumented, TaskMetrics, TaskMonitor};
+pub use task::{Instrumented, TaskIntervals, TaskMetrics, TaskMonitor};


### PR DESCRIPTION
The type `task::TaskIntervals` is public, but inside the `task` module which is private and not exported. This makes it impossible to reference the type outside of this crate. We should export the `TaskIntervals` type so users  of `tokio-metrics` can reference this type.