### PR TITLE
docs: replace version-pinned docs links in readme with latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,35 +117,35 @@ loop {
 - **[`mean_long_delay_duration`]**
   The mean duration of long schedules.
 
-[`instrumented_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
-[`dropped_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count
-[`first_poll_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.first_poll_count
-[`total_first_poll_delay`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_first_poll_delay 
-[`total_idled_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idled_count
-[`total_idle_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_idle_duration
-[`max_idle_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.max_idle_duration
-[`total_scheduled_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_count 
-[`total_scheduled_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_duration
-[`total_poll_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_count
-[`total_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_duration
-[`total_fast_poll_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_count 
-[`total_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_duration 
-[`total_slow_poll_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_count
-[`total_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_duration
-[`total_short_delay_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_count
-[`total_short_delay_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_duration
-[`total_long_delay_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_count
-[`total_long_delay_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_duration
-[`mean_first_poll_delay`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_first_poll_delay
-[`mean_idle_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_idle_duration
-[`mean_scheduled_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_scheduled_duration
-[`mean_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_poll_duration
-[`slow_poll_ratio`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.slow_poll_ratio
-[`long_delay_ratio`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.long_delay_ratio
-[`mean_fast_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_fast_poll_duration
-[`mean_slow_poll_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_slow_poll_duration
-[`mean_short_delay_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_short_delay_duration
-[`mean_long_delay_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetrics.html#method.mean_long_delay_duration
+[`instrumented_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.instrumented_count
+[`dropped_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.dropped_count
+[`first_poll_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.first_poll_count
+[`total_first_poll_delay`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_first_poll_delay
+[`total_idled_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_idled_count
+[`total_idle_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_idle_duration
+[`max_idle_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.max_idle_duration
+[`total_scheduled_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_count
+[`total_scheduled_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_scheduled_duration
+[`total_poll_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_count
+[`total_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_poll_duration
+[`total_fast_poll_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_count
+[`total_fast_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_fast_poll_duration
+[`total_slow_poll_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_count
+[`total_slow_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_slow_poll_duration
+[`total_short_delay_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_count
+[`total_short_delay_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_short_delay_duration
+[`total_long_delay_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_count
+[`total_long_delay_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#structfield.total_long_delay_duration
+[`mean_first_poll_delay`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_first_poll_delay
+[`mean_idle_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_idle_duration
+[`mean_scheduled_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_scheduled_duration
+[`mean_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_poll_duration
+[`slow_poll_ratio`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.slow_poll_ratio
+[`long_delay_ratio`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.long_delay_ratio
+[`mean_fast_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_fast_poll_duration
+[`mean_slow_poll_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_slow_poll_duration
+[`mean_short_delay_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_short_delay_duration
+[`mean_long_delay_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetrics.html#method.mean_long_delay_duration
 
 ## Getting Started With Runtime Metrics
 
@@ -179,7 +179,7 @@ The `rt` feature of `tokio-metrics` is on by default; simply check that you do
 not set `default-features = false` when declaring it as a dependency; e.g.:
 ```toml
 [dependencies]
-tokio-metrics = "0.4.7"
+tokio-metrics = "0.5"
 ```
 
 From within a Tokio runtime, use `RuntimeMonitor` to monitor key metrics of
@@ -227,7 +227,7 @@ tokio::spawn(do_work());
   The current number of alive tasks in the runtime.
 
 #### Unstable Base Metrics
-- **[`mean_poll_duration`](https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration)**
+- **[`mean_poll_duration`](https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration)**
   The average duration of a single invocation of poll on a task.
 - **[`mean_poll_duration_worker_min`]**
   The average duration of a single invocation of poll on a task on the worker with the lowest value.
@@ -299,49 +299,49 @@ tokio::spawn(do_work());
   The ratio of the number of tasks that have been polled and the number of times worker threads unparked but performed no work before parking again.
 
 
-[`workers_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
-[`total_park_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
-[`max_park_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_park_count
-[`min_park_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_park_count
-[`total_busy_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_busy_duration
-[`max_busy_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_busy_duration
-[`min_busy_duration`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_busy_duration
-[`global_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.global_queue_depth
-[`elapsed`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.elapsed
-[`mean_poll_duration_worker_min`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration_worker_min
-[`mean_poll_duration_worker_max`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration_worker_max
-[`poll_time_histogram`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.poll_time_histogram
-[`total_noop_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_noop_count
-[`max_noop_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_noop_count
-[`min_noop_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_noop_count
-[`total_steal_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_count
-[`max_steal_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_count
-[`min_steal_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_count
-[`total_steal_operations`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_operations
-[`max_steal_operations`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_operations
-[`min_steal_operations`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_operations
-[`num_remote_schedules`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.num_remote_schedules
-[`total_local_schedule_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_schedule_count
-[`max_local_schedule_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_schedule_count
-[`min_local_schedule_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_schedule_count
-[`total_overflow_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_overflow_count
-[`max_overflow_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_overflow_count
-[`min_overflow_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_overflow_count
-[`total_polls_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_polls_count
-[`max_polls_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_polls_count
-[`min_polls_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_polls_count
-[`injection_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.injection_queue_depth
-[`total_local_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_queue_depth
-[`max_local_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_queue_depth
-[`min_local_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_queue_depth
-[`blocking_queue_depth`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.blocking_queue_depth
-[`live_tasks_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.live_tasks_count
-[`blocking_threads_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.blocking_threads_count
-[`idle_blocking_threads_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.idle_blocking_threads_count
-[`budget_forced_yield_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.budget_forced_yield_count
-[`io_driver_ready_count`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#structfield.io_driver_ready_count
-[`busy_ratio`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#method.busy_ratio
-[`mean_polls_per_park`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetrics.html#method.mean_polls_per_park
+[`workers_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.workers_count
+[`total_park_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_park_count
+[`max_park_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_park_count
+[`min_park_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_park_count
+[`total_busy_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_busy_duration
+[`max_busy_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_busy_duration
+[`min_busy_duration`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_busy_duration
+[`global_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.global_queue_depth
+[`elapsed`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.elapsed
+[`mean_poll_duration_worker_min`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration_worker_min
+[`mean_poll_duration_worker_max`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.mean_poll_duration_worker_max
+[`poll_time_histogram`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.poll_time_histogram
+[`total_noop_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_noop_count
+[`max_noop_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_noop_count
+[`min_noop_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_noop_count
+[`total_steal_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_count
+[`max_steal_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_count
+[`min_steal_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_count
+[`total_steal_operations`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_steal_operations
+[`max_steal_operations`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_steal_operations
+[`min_steal_operations`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_steal_operations
+[`num_remote_schedules`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.num_remote_schedules
+[`total_local_schedule_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_schedule_count
+[`max_local_schedule_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_schedule_count
+[`min_local_schedule_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_schedule_count
+[`total_overflow_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_overflow_count
+[`max_overflow_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_overflow_count
+[`min_overflow_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_overflow_count
+[`total_polls_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_polls_count
+[`max_polls_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_polls_count
+[`min_polls_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_polls_count
+[`injection_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.injection_queue_depth
+[`total_local_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.total_local_queue_depth
+[`max_local_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.max_local_queue_depth
+[`min_local_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.min_local_queue_depth
+[`blocking_queue_depth`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.blocking_queue_depth
+[`live_tasks_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.live_tasks_count
+[`blocking_threads_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.blocking_threads_count
+[`idle_blocking_threads_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.idle_blocking_threads_count
+[`budget_forced_yield_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.budget_forced_yield_count
+[`io_driver_ready_count`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#structfield.io_driver_ready_count
+[`busy_ratio`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#method.busy_ratio
+[`mean_polls_per_park`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html#method.mean_polls_per_park
 
 
 ## Collecting Metrics via metrics.rs
@@ -357,12 +357,12 @@ The exported metrics by default will be exported with their name, preceded by `t
 If you want to use [Prometheus], you could have this `Cargo.toml`:
 
 [Prometheus]: https://prometheus.io
-[`RuntimeMetricsReporterBuilder::with_metrics_transformer`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.RuntimeMetricsReporterBuilder.html#method.with_metrics_transformer
-[`TaskMetricsReporterBuilder::new`]: https://docs.rs/tokio-metrics/0.4.*/tokio_metrics/struct.TaskMetricsReporterBuilder.html#method.new
+[`RuntimeMetricsReporterBuilder::with_metrics_transformer`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetricsReporterBuilder.html#method.with_metrics_transformer
+[`TaskMetricsReporterBuilder::new`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.TaskMetricsReporterBuilder.html#method.new
 
 ```toml
 [dependencies]
-tokio-metrics = { version = "0.4.7", features = ["metrics-rs-integration"] }
+tokio-metrics = { version = "0.5", features = ["metrics-rs-integration"] }
 metrics = "0.24"
 # You don't actually need to use the Prometheus exporter with uds-listener enabled,
 # it's just here as an example.


### PR DESCRIPTION
Replaces version-pinned links in readme with /latest/