### PR TITLE
feat: add per-request task metrics via FutureMonitor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,5 +213,6 @@ mod task;
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics-rs-integration")))]
 pub use task::metrics_rs_integration::{TaskMetricsReporter, TaskMetricsReporterBuilder};
 pub use task::{
-    Instrumented, TaskIntervals, TaskMetrics, TaskMonitor, TaskMonitorCore, TaskMonitorCoreBuilder,
+    Instrumented, InstrumentedRequest, RequestMonitor, RequestTaskMetrics, TaskIntervals,
+    TaskMetrics, TaskMonitor, TaskMonitorCore, TaskMonitorCoreBuilder, TaskScheduling,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,6 @@ mod task;
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics-rs-integration")))]
 pub use task::metrics_rs_integration::{TaskMetricsReporter, TaskMetricsReporterBuilder};
 pub use task::{
-    Instrumented, InstrumentedRequest, RequestMonitor, RequestTaskMetrics, TaskIntervals,
-    TaskMetrics, TaskMonitor, TaskMonitorCore, TaskMonitorCoreBuilder, TaskScheduling,
+    FutureMetrics, FutureMonitor, Instrumented, MonitoredFuture, TaskIntervals, TaskMetrics,
+    TaskMonitor, TaskMonitorCore, TaskMonitorCoreBuilder, TaskScheduling,
 };

--- a/src/task.rs
+++ b/src/task.rs
@@ -3083,7 +3083,7 @@ impl<M: Send + Sync> ArcWake for State<M> {
 #[non_exhaustive]
 #[cfg_attr(
     feature = "metrique-integration",
-    metrique::unit_of_work::metrics(subfield_owned)
+    metrique::unit_of_work::metrics(subfield)
 )]
 #[derive(Debug, Clone, Default)]
 pub struct FutureMetrics {

--- a/src/task.rs
+++ b/src/task.rs
@@ -622,15 +622,13 @@ impl TaskMonitorBuilder {
     }
 
     /// Specifies the threshold at which polls are considered 'slow'.
-    pub fn with_slow_poll_threshold(&mut self, threshold: Duration) -> &mut Self {
-        self.0.slow_poll_threshold = Some(threshold);
-        self
+    pub fn with_slow_poll_threshold(self, threshold: Duration) -> Self {
+        Self(self.0.with_slow_poll_threshold(threshold))
     }
 
     /// Specifies the threshold at which schedules are considered 'long'.
-    pub fn with_long_delay_threshold(&mut self, threshold: Duration) -> &mut Self {
-        self.0.long_delay_threshold = Some(threshold);
-        self
+    pub fn with_long_delay_threshold(self, threshold: Duration) -> Self {
+        Self(self.0.with_long_delay_threshold(threshold))
     }
 
     /// Records each instrumented task's scheduling delay so that a
@@ -640,9 +638,8 @@ impl TaskMonitorBuilder {
     /// Off by default: tasks instrumented by a monitor without this enabled pay
     /// no extra per-poll cost. Enable it on the monitor wrapping the larger task
     /// when you want [`RequestMonitor`]'s scheduling metrics to be populated.
-    pub fn record_request_scheduling(&mut self) -> &mut Self {
-        self.0.record_scheduling_log = true;
-        self
+    pub fn record_request_scheduling(self) -> Self {
+        Self(self.0.record_request_scheduling())
     }
 
     /// Consume the builder, producing a [`TaskMonitor`].
@@ -3272,9 +3269,7 @@ impl<F: Future> Future for InstrumentedRequest<F> {
 /// async fn main() {
 ///     // the larger task is instrumented once; `record_request_scheduling`
 ///     // enables per-request scheduling-delay capture
-///     let mut builder = TaskMonitor::builder();
-///     builder.record_request_scheduling();
-///     let task_monitor = builder.build();
+///     let task_monitor = TaskMonitor::builder().record_request_scheduling().build();
 ///     task_monitor.instrument(async {
 ///         // each unit of work within the task is measured on its own
 ///         let (_output, metrics) = RequestMonitor::new()
@@ -3553,9 +3548,7 @@ mod request_monitor_tests {
     async fn try_current_tracks_root_scheduling_when_opted_in() {
         assert!(TaskScheduling::try_current().is_none());
 
-        let mut builder = TaskMonitor::builder();
-        builder.record_request_scheduling();
-        let monitor = builder.build();
+        let monitor = TaskMonitor::builder().record_request_scheduling().build();
         monitor
             .instrument(async {
                 // The log exists from the first poll, even before any scheduling.

--- a/src/task.rs
+++ b/src/task.rs
@@ -1783,7 +1783,9 @@ impl TaskScheduling {
             total_scheduled_duration: self
                 .total_scheduled_duration
                 .saturating_sub(earlier.total_scheduled_duration),
-            long_delay_count: self.long_delay_count.saturating_sub(earlier.long_delay_count),
+            long_delay_count: self
+                .long_delay_count
+                .saturating_sub(earlier.long_delay_count),
         }
     }
 }
@@ -3129,7 +3131,8 @@ impl SpanState {
     /// scheduling log is in scope.
     fn record(&self, now: TaskScheduling) {
         if !self.started.swap(true, SeqCst) {
-            self.start_scheduled_count.store(now.scheduled_count, SeqCst);
+            self.start_scheduled_count
+                .store(now.scheduled_count, SeqCst);
             self.start_scheduled_duration_ns
                 .store(duration_to_nanos(now.total_scheduled_duration), SeqCst);
             self.start_long_delay_count
@@ -3139,7 +3142,8 @@ impl SpanState {
         self.end_scheduled_count.store(now.scheduled_count, SeqCst);
         self.end_scheduled_duration_ns
             .store(duration_to_nanos(now.total_scheduled_duration), SeqCst);
-        self.end_long_delay_count.store(now.long_delay_count, SeqCst);
+        self.end_long_delay_count
+            .store(now.long_delay_count, SeqCst);
         if let Some(first_poll) = self.first_poll.get() {
             self.total_duration_ns
                 .store(duration_to_nanos(first_poll.elapsed()), SeqCst);
@@ -3183,7 +3187,8 @@ pin_project! {
 
 impl<F> std::fmt::Debug for InstrumentedRequest<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InstrumentedRequest").finish_non_exhaustive()
+        f.debug_struct("InstrumentedRequest")
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -605,7 +605,7 @@ pub struct TaskMonitorCore {
     /// Whether instrumented tasks should publish their scheduling delay as a
     /// task-local for [`RequestMonitor`] to sample. Off by default so the common
     /// case pays nothing; enabled via
-    /// [`TaskMonitorBuilder::record_request_scheduling`]. Kept out of
+    /// [`TaskMonitorBuilder::publish_scheduling_delay`]. Kept out of
     /// [`RawMetrics`] so that struct's (heavily contended) layout is unchanged.
     record_scheduling_log: bool,
 }
@@ -638,8 +638,8 @@ impl TaskMonitorBuilder {
     /// Off by default: tasks instrumented by a monitor without this enabled pay
     /// no extra per-poll cost. Enable it on the monitor wrapping the larger task
     /// when you want [`RequestMonitor`]'s scheduling metrics to be populated.
-    pub fn record_request_scheduling(self) -> Self {
-        Self(self.0.record_request_scheduling())
+    pub fn publish_scheduling_delay(self) -> Self {
+        Self(self.0.publish_scheduling_delay())
     }
 
     /// Consume the builder, producing a [`TaskMonitor`].
@@ -699,8 +699,8 @@ impl TaskMonitorCoreBuilder {
     /// to a single request via [`TaskScheduling`].
     ///
     /// Off by default; see
-    /// [`TaskMonitorBuilder::record_request_scheduling`] for details.
-    pub const fn record_request_scheduling(self) -> Self {
+    /// [`TaskMonitorBuilder::publish_scheduling_delay`] for details.
+    pub const fn publish_scheduling_delay(self) -> Self {
         Self {
             record_scheduling_log: true,
             ..self
@@ -1689,7 +1689,7 @@ struct State<M> {
     /// the task is being polled so that nested futures (e.g. a per-request
     /// [`RequestMonitor`]) can attribute scheduling delay to themselves. `None`
     /// unless the monitor opted in via
-    /// [`TaskMonitorBuilder::record_request_scheduling`], so the common case
+    /// [`TaskMonitorBuilder::publish_scheduling_delay`], so the common case
     /// allocates nothing and pays no per-poll cost.
     log: Option<Arc<SchedulingLog>>,
 }
@@ -3267,9 +3267,9 @@ impl<F: Future> Future for InstrumentedRequest<F> {
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     // the larger task is instrumented once; `record_request_scheduling`
+///     // the larger task is instrumented once; `publish_scheduling_delay`
 ///     // enables per-request scheduling-delay capture
-///     let task_monitor = TaskMonitor::builder().record_request_scheduling().build();
+///     let task_monitor = TaskMonitor::builder().publish_scheduling_delay().build();
 ///     task_monitor.instrument(async {
 ///         // each unit of work within the task is measured on its own
 ///         let (_output, metrics) = RequestMonitor::new()
@@ -3548,7 +3548,7 @@ mod request_monitor_tests {
     async fn try_current_tracks_root_scheduling_when_opted_in() {
         assert!(TaskScheduling::try_current().is_none());
 
-        let monitor = TaskMonitor::builder().record_request_scheduling().build();
+        let monitor = TaskMonitor::builder().publish_scheduling_delay().build();
         monitor
             .instrument(async {
                 // The log exists from the first poll, even before any scheduling.

--- a/src/task.rs
+++ b/src/task.rs
@@ -640,8 +640,9 @@ impl TaskMonitorBuilder {
     /// Off by default: tasks instrumented by a monitor without this enabled pay
     /// no extra per-poll cost. Enable it on the monitor wrapping the larger task
     /// when you want [`FutureMonitor`]'s scheduling metrics to be populated.
-    pub fn publish_scheduling_delay(self) -> Self {
-        Self(self.0.publish_scheduling_delay())
+    pub fn publish_scheduling_delay(&mut self) -> &mut Self {
+        self.0.record_scheduling_log = true;
+        self
     }
 
     /// Consume the builder, producing a [`TaskMonitor`].
@@ -3271,7 +3272,9 @@ impl<F: Future> Future for MonitoredFuture<F> {
 /// async fn main() {
 ///     // the larger task is instrumented once; `publish_scheduling_delay`
 ///     // enables per-future scheduling-delay capture
-///     let task_monitor = TaskMonitor::builder().publish_scheduling_delay().build();
+///     let mut builder = TaskMonitor::builder();
+///     builder.publish_scheduling_delay();
+///     let task_monitor = builder.build();
 ///     task_monitor.instrument(async {
 ///         // each unit of work within the task is measured on its own
 ///         let (_output, metrics) = FutureMonitor::new()
@@ -3550,7 +3553,9 @@ mod future_monitor_tests {
     async fn try_current_tracks_root_scheduling_when_opted_in() {
         assert!(TaskScheduling::try_current().is_none());
 
-        let monitor = TaskMonitor::builder().publish_scheduling_delay().build();
+        let mut builder = TaskMonitor::builder();
+        builder.publish_scheduling_delay();
+        let monitor = builder.build();
         monitor
             .instrument(async {
                 // The log exists from the first poll, even before any scheduling.

--- a/src/task.rs
+++ b/src/task.rs
@@ -3224,8 +3224,7 @@ pin_project! {
 
 impl<F> std::fmt::Debug for MonitoredFuture<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MonitoredFuture")
-            .finish_non_exhaustive()
+        f.debug_struct("MonitoredFuture").finish_non_exhaustive()
     }
 }
 
@@ -3652,7 +3651,11 @@ mod future_monitor_tests {
 
             // Each monitor captures only its own future: the inner one sees just
             // the sleep, the outer one additionally sees its yield poll.
-            assert_eq!(inner.poll_count, 2, "inner poll_count = {}", inner.poll_count);
+            assert_eq!(
+                inner.poll_count, 2,
+                "inner poll_count = {}",
+                inner.poll_count
+            );
             assert_eq!(inner.idle_count, 1);
             assert_eq!(inner.total_idle_duration, Duration::from_secs(1));
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -3183,14 +3183,34 @@ impl SpanState {
     }
 }
 
+fn build_request_metrics(monitor: &TaskMonitor, span: &SpanState) -> RequestTaskMetrics {
+    let local = monitor.cumulative();
+    let scheduling = span.scheduling_delta();
+    RequestTaskMetrics {
+        poll_count: local.total_poll_count,
+        total_poll_duration: local.total_poll_duration,
+        slow_poll_count: local.total_slow_poll_count,
+        idle_count: local.total_idled_count,
+        total_idle_duration: local.total_idle_duration,
+        max_idle_duration: local.max_idle_duration,
+        first_poll_delay: local.total_first_poll_delay,
+        total_duration: span.total_duration(),
+        scheduled_count: scheduling.scheduled_count,
+        total_scheduled_duration: scheduling.total_scheduled_duration,
+        long_delay_count: scheduling.long_delay_count,
+    }
+}
+
 pin_project! {
     /// The future returned by [`RequestMonitor::instrument`].
     ///
     /// Wraps the request's future, capturing its per-poll metrics locally and
-    /// sampling the surrounding task's scheduling delay at each poll.
+    /// sampling the surrounding task's scheduling delay at each poll. Resolves to
+    /// the wrapped future's output paired with the captured [`RequestTaskMetrics`].
     pub struct InstrumentedRequest<F> {
         #[pin]
         inner: Instrumented<F, TaskMonitor>,
+        monitor: TaskMonitor,
         span: Arc<SpanState>,
     }
 }
@@ -3203,9 +3223,9 @@ impl<F> std::fmt::Debug for InstrumentedRequest<F> {
 }
 
 impl<F: Future> Future for InstrumentedRequest<F> {
-    type Output = F::Output;
+    type Output = (F::Output, RequestTaskMetrics);
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         // Sample the root task's scheduling log *before* delegating to the inner
         // `Instrumented`, while the root task's log is the one in scope (the
@@ -3218,7 +3238,13 @@ impl<F: Future> Future for InstrumentedRequest<F> {
         // just finished — including the final one that returns `Ready` — is
         // captured in `total_duration`.
         this.span.record_poll_end();
-        ret
+        match ret {
+            Poll::Ready(output) => {
+                let metrics = build_request_metrics(this.monitor, this.span);
+                Poll::Ready((output, metrics))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 
@@ -3234,6 +3260,10 @@ impl<F: Future> Future for InstrumentedRequest<F> {
 /// metrics to be populated the surrounding task must itself be instrumented with
 /// [`TaskMonitor::instrument`].
 ///
+/// `RequestMonitor` instruments exactly one future: [`instrument`] consumes the
+/// monitor, so it cannot be reused, and the returned future resolves to the
+/// wrapped output together with the captured [`RequestTaskMetrics`].
+///
 /// ##### Examples
 /// ```
 /// use tokio_metrics::{RequestMonitor, TaskMonitor};
@@ -3247,16 +3277,22 @@ impl<F: Future> Future for InstrumentedRequest<F> {
 ///     let task_monitor = builder.build();
 ///     task_monitor.instrument(async {
 ///         // each unit of work within the task is measured on its own
-///         let request = RequestMonitor::new();
-///         request.instrument(async {
-///             tokio::task::yield_now().await;
-///         }).await;
+///         let (_output, metrics) = RequestMonitor::new()
+///             .instrument(async {
+///                 tokio::task::yield_now().await;
+///             })
+///             .await;
 ///
-///         assert!(request.metrics().poll_count >= 1);
+///         assert!(metrics.poll_count >= 1);
 ///     }).await;
 /// }
 /// ```
-#[derive(Clone, Debug, Default)]
+///
+/// [`instrument`]: RequestMonitor::instrument
+// Deliberately not `Clone`: cloning would share the underlying span and let two
+// instrumented futures be measured as one, which is exactly the reuse `instrument`
+// (by consuming `self`) is meant to prevent.
+#[derive(Debug, Default)]
 pub struct RequestMonitor {
     monitor: TaskMonitor,
     span: Arc<SpanState>,
@@ -3277,33 +3313,16 @@ impl RequestMonitor {
         }
     }
 
-    /// Instruments the request's future. Poll it to completion, then read the
-    /// captured metrics with [`metrics`](RequestMonitor::metrics).
-    pub fn instrument<F>(&self, task: F) -> InstrumentedRequest<F> {
+    /// Instruments the request's future, consuming the monitor.
+    ///
+    /// Taking `self` by value means a `RequestMonitor` can only instrument one
+    /// future. Await the returned [`InstrumentedRequest`] to get the future's
+    /// output alongside its [`RequestTaskMetrics`].
+    pub fn instrument<F>(self, task: F) -> InstrumentedRequest<F> {
         InstrumentedRequest {
             inner: self.monitor.instrument(task),
-            span: self.span.clone(),
-        }
-    }
-
-    /// Produces the [`RequestTaskMetrics`] captured so far for this request.
-    ///
-    /// Typically called after the instrumented future has completed.
-    pub fn metrics(&self) -> RequestTaskMetrics {
-        let local = self.monitor.cumulative();
-        let scheduling = self.span.scheduling_delta();
-        RequestTaskMetrics {
-            poll_count: local.total_poll_count,
-            total_poll_duration: local.total_poll_duration,
-            slow_poll_count: local.total_slow_poll_count,
-            idle_count: local.total_idled_count,
-            total_idle_duration: local.total_idle_duration,
-            max_idle_duration: local.max_idle_duration,
-            first_poll_delay: local.total_first_poll_delay,
-            total_duration: self.span.total_duration(),
-            scheduled_count: scheduling.scheduled_count,
-            total_scheduled_duration: scheduling.total_scheduled_duration,
-            long_delay_count: scheduling.long_delay_count,
+            monitor: self.monitor,
+            span: self.span,
         }
     }
 }
@@ -3497,15 +3516,13 @@ mod request_monitor_tests {
         let task_monitor = TaskMonitor::new();
         task_monitor
             .instrument(async {
-                let request = RequestMonitor::new();
-                request
+                let (_, m) = RequestMonitor::new()
                     .instrument(async {
                         tokio::task::yield_now().await; // an extra poll
                         tokio::time::sleep(Duration::from_secs(1)).await; // idle
                     })
                     .await;
 
-                let m = request.metrics();
                 assert!(m.poll_count >= 2, "poll_count = {}", m.poll_count);
                 assert!(m.idle_count >= 1, "idle_count = {}", m.idle_count);
                 assert!(
@@ -3521,14 +3538,12 @@ mod request_monitor_tests {
     async fn scheduling_is_zero_without_instrumented_root() {
         // No surrounding `TaskMonitor::instrument`, so `try_current()` is `None`
         // and no scheduling delay is attributed — but local metrics still work.
-        let request = RequestMonitor::new();
-        request
+        let (_, m) = RequestMonitor::new()
             .instrument(async {
                 tokio::task::yield_now().await;
             })
             .await;
 
-        let m = request.metrics();
         assert_eq!(m.scheduled_count, 0);
         assert_eq!(m.total_scheduled_duration, Duration::ZERO);
         assert!(m.poll_count >= 1, "poll_count = {}", m.poll_count);
@@ -3570,21 +3585,35 @@ mod request_monitor_tests {
             .await;
     }
 
+    #[tokio::test]
+    async fn instrument_yields_output_and_metrics() {
+        // `instrument` consumes the monitor and resolves to the future's output
+        // paired with its captured metrics — so a monitor can only ever measure
+        // a single future.
+        let (output, m) = RequestMonitor::new()
+            .instrument(async {
+                tokio::task::yield_now().await;
+                "done"
+            })
+            .await;
+
+        assert_eq!(output, "done");
+        assert!(m.poll_count >= 1, "poll_count = {}", m.poll_count);
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn total_duration_includes_final_poll_execution() {
         // The request completes in a single poll that spends real time
         // executing. `total_duration` is stamped after the poll, so it must
         // include that execution time (a regression would record it before the
         // poll and report ~0).
-        let request = RequestMonitor::new();
-        request
+        let (_, m) = RequestMonitor::new()
             .instrument(async {
                 let start = std::time::Instant::now();
                 while start.elapsed() < Duration::from_millis(20) {}
             })
             .await;
 
-        let m = request.metrics();
         assert!(m.poll_count == 1, "poll_count = {}", m.poll_count);
         assert!(
             m.total_duration >= Duration::from_millis(15),

--- a/src/task.rs
+++ b/src/task.rs
@@ -3621,4 +3621,43 @@ mod future_monitor_tests {
             m.total_duration
         );
     }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn nested_future_monitors_capture_independently() {
+        let mut builder = TaskMonitor::builder();
+        builder.publish_scheduling_delay();
+        let root = builder.build();
+
+        root.instrument(async {
+            // An outer monitored future that does one extra poll of its own, then
+            // runs an inner monitored future that sleeps.
+            let (inner, outer) = FutureMonitor::new()
+                .instrument(async {
+                    tokio::task::yield_now().await; // outer-only extra poll
+                    let (_, inner) = FutureMonitor::new()
+                        .instrument(async {
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        })
+                        .await;
+                    inner
+                })
+                .await;
+
+            // Each monitor captures only its own future: the inner one sees just
+            // the sleep, the outer one additionally sees its yield poll.
+            assert_eq!(inner.poll_count, 2, "inner poll_count = {}", inner.poll_count);
+            assert_eq!(inner.idle_count, 1);
+            assert_eq!(inner.total_idle_duration, Duration::from_secs(1));
+
+            assert!(
+                outer.poll_count > inner.poll_count,
+                "outer {} should exceed inner {}",
+                outer.poll_count,
+                inner.poll_count
+            );
+            // The outer future is idle for the whole time the inner one sleeps.
+            assert_eq!(outer.total_idle_duration, Duration::from_secs(1));
+        })
+        .await;
+    }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -622,13 +622,15 @@ impl TaskMonitorBuilder {
     }
 
     /// Specifies the threshold at which polls are considered 'slow'.
-    pub fn with_slow_poll_threshold(self, threshold: Duration) -> Self {
-        Self(self.0.with_slow_poll_threshold(threshold))
+    pub fn with_slow_poll_threshold(&mut self, threshold: Duration) -> &mut Self {
+        self.0.slow_poll_threshold = Some(threshold);
+        self
     }
 
     /// Specifies the threshold at which schedules are considered 'long'.
-    pub fn with_long_delay_threshold(self, threshold: Duration) -> Self {
-        Self(self.0.with_long_delay_threshold(threshold))
+    pub fn with_long_delay_threshold(&mut self, threshold: Duration) -> &mut Self {
+        self.0.long_delay_threshold = Some(threshold);
+        self
     }
 
     /// Records each instrumented task's scheduling delay so that a

--- a/src/task.rs
+++ b/src/task.rs
@@ -1715,6 +1715,11 @@ struct SchedulingLog {
 thread_local! {
     /// The scheduling log of the innermost [`Instrumented`] task currently being
     /// polled on this thread, if any.
+    ///
+    /// This is a hand-rolled task-local built on a `thread_local!`: it is only
+    /// set for the duration of a single synchronous poll (see
+    /// [`SchedulingLogGuard`]) and never held across an `.await`, so the usual
+    /// hazard of thread-locals in async code does not apply.
     static CURRENT_SCHEDULING_LOG: RefCell<Option<Arc<SchedulingLog>>> =
         const { RefCell::new(None) };
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -603,7 +603,7 @@ impl AsRef<TaskMonitorCore> for TaskMonitor {
 pub struct TaskMonitorCore {
     metrics: RawMetrics,
     /// Whether instrumented tasks should publish their scheduling delay as a
-    /// task-local for [`RequestMonitor`] to sample. Off by default so the common
+    /// task-local for [`FutureMonitor`] to sample. Off by default so the common
     /// case pays nothing; enabled via
     /// [`TaskMonitorBuilder::publish_scheduling_delay`]. Kept out of
     /// [`RawMetrics`] so that struct's (heavily contended) layout is unchanged.
@@ -632,12 +632,12 @@ impl TaskMonitorBuilder {
     }
 
     /// Records each instrumented task's scheduling delay so that a
-    /// [`RequestMonitor`] running within the task can attribute scheduling delay
-    /// to a single request via [`TaskScheduling`].
+    /// [`FutureMonitor`] running within the task can attribute scheduling delay
+    /// to a single future via [`TaskScheduling`].
     ///
     /// Off by default: tasks instrumented by a monitor without this enabled pay
     /// no extra per-poll cost. Enable it on the monitor wrapping the larger task
-    /// when you want [`RequestMonitor`]'s scheduling metrics to be populated.
+    /// when you want [`FutureMonitor`]'s scheduling metrics to be populated.
     pub fn publish_scheduling_delay(self) -> Self {
         Self(self.0.publish_scheduling_delay())
     }
@@ -695,8 +695,8 @@ impl TaskMonitorCoreBuilder {
     }
 
     /// Records each instrumented task's scheduling delay so that a
-    /// [`RequestMonitor`] running within the task can attribute scheduling delay
-    /// to a single request via [`TaskScheduling`].
+    /// [`FutureMonitor`] running within the task can attribute scheduling delay
+    /// to a single future via [`TaskScheduling`].
     ///
     /// Off by default; see
     /// [`TaskMonitorBuilder::publish_scheduling_delay`] for details.
@@ -1686,8 +1686,8 @@ struct State<M> {
     waker: AtomicWaker,
 
     /// Cumulative scheduling info for this task, published as a task-local while
-    /// the task is being polled so that nested futures (e.g. a per-request
-    /// [`RequestMonitor`]) can attribute scheduling delay to themselves. `None`
+    /// the task is being polled so that nested futures (e.g. a per-future
+    /// [`FutureMonitor`]) can attribute scheduling delay to themselves. `None`
     /// unless the monitor opted in via
     /// [`TaskMonitorBuilder::publish_scheduling_delay`], so the common case
     /// allocates nothing and pays no per-poll cost.
@@ -1748,8 +1748,8 @@ impl Drop for SchedulingLogGuard {
 /// been instrumented with [`TaskMonitor::instrument`]. Scheduling delay can only
 /// be measured by the root future the runtime schedules, so a future running
 /// within a larger task samples this at two points and reports the difference —
-/// this is exactly what [`RequestMonitor`] does to attribute scheduling delay to
-/// a single request.
+/// this is exactly what [`FutureMonitor`] does to attribute scheduling delay to
+/// a single future.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TaskScheduling {
@@ -2989,7 +2989,7 @@ fn instrument_poll<T, M: AsRef<TaskMonitorCore> + Send + Sync + 'static, Out>(
 
         // mirror the same scheduling accounting into this task's own log so that
         // futures running within the task can attribute scheduling delay to
-        // their own lifetime (see `RequestMonitor`). Only present when the
+        // their own lifetime (see `FutureMonitor`). Only present when the
         // monitor opted in, so the common case skips this entirely.
         if let Some(log) = &state.log {
             log.scheduled_count.fetch_add(1, SeqCst);
@@ -3068,48 +3068,48 @@ impl<M: Send + Sync> ArcWake for State<M> {
     }
 }
 
-/// Key metrics of a single instrumented future — a "request" running within a
-/// larger task — as captured by a [`RequestMonitor`].
+/// Key metrics of a single instrumented future running within a larger task, as
+/// captured by a [`FutureMonitor`].
 ///
 /// Unlike [`TaskMetrics`], which aggregates across every future instrumented by
 /// a [`TaskMonitor`], these metrics describe just one future. Idle, poll, and
 /// first-poll metrics are measured locally from that future's own polls, so they
 /// remain accurate even when the surrounding task interleaves other work.
 /// Scheduling metrics are sampled from the root task's [`TaskScheduling`] log
-/// over the request's lifetime (see [`RequestMonitor`]).
+/// over the future's lifetime (see [`FutureMonitor`]).
 #[non_exhaustive]
 #[cfg_attr(
     feature = "metrique-integration",
     metrique::unit_of_work::metrics(subfield_owned)
 )]
 #[derive(Debug, Clone, Default)]
-pub struct RequestTaskMetrics {
-    /// The number of times the request's future was polled.
+pub struct FutureMetrics {
+    /// The number of times the future was polled.
     pub poll_count: u64,
-    /// The total time spent polling the request's future.
+    /// The total time spent polling the future.
     pub total_poll_duration: Duration,
     /// The number of polls that exceeded the monitor's slow-poll threshold.
     pub slow_poll_count: u64,
-    /// The number of times the request idled, waiting to be awoken.
+    /// The number of times the future idled, waiting to be awoken.
     pub idle_count: u64,
-    /// The total time the request spent idle, waiting on external events.
+    /// The total time the future spent idle, waiting on external events.
     pub total_idle_duration: Duration,
-    /// The longest single idle the request experienced.
+    /// The longest single idle the future experienced.
     pub max_idle_duration: Duration,
-    /// The delay between the request being instrumented and its first poll.
+    /// The delay between the future being instrumented and its first poll.
     pub first_poll_delay: Duration,
-    /// The wall-clock time from the request's first poll to its completion.
+    /// The wall-clock time from the future's first poll to its completion.
     pub total_duration: Duration,
-    /// The number of times the underlying task was scheduled while the request was alive.
+    /// The number of times the underlying task was scheduled while the future was alive.
     pub scheduled_count: u64,
-    /// The total scheduling delay the underlying task incurred while the request was alive.
+    /// The total scheduling delay the underlying task incurred while the future was alive.
     pub total_scheduled_duration: Duration,
     /// The number of those scheduling delays that crossed the long-delay threshold.
     pub long_delay_count: u64,
 }
 
-/// Per-request capture state shared between a [`RequestMonitor`] and the
-/// [`InstrumentedRequest`] future it produces.
+/// Per-future capture state shared between a [`FutureMonitor`] and the
+/// [`MonitoredFuture`] future it produces.
 #[derive(Debug, Default)]
 struct SpanState {
     started: AtomicBool,
@@ -3129,7 +3129,7 @@ fn duration_to_nanos(d: Duration) -> u64 {
 
 impl SpanState {
     /// Records the root scheduling snapshot for a poll. Called at the top of
-    /// every poll of the [`InstrumentedRequest`], while the root task's
+    /// every poll of the [`MonitoredFuture`], while the root task's
     /// scheduling log is in scope.
     fn record_poll_start(&self, now: TaskScheduling) {
         if !self.started.swap(true, SeqCst) {
@@ -3180,10 +3180,10 @@ impl SpanState {
     }
 }
 
-fn build_request_metrics(monitor: &TaskMonitor, span: &SpanState) -> RequestTaskMetrics {
+fn build_future_metrics(monitor: &TaskMonitor, span: &SpanState) -> FutureMetrics {
     let local = monitor.cumulative();
     let scheduling = span.scheduling_delta();
-    RequestTaskMetrics {
+    FutureMetrics {
         poll_count: local.total_poll_count,
         total_poll_duration: local.total_poll_duration,
         slow_poll_count: local.total_slow_poll_count,
@@ -3199,12 +3199,12 @@ fn build_request_metrics(monitor: &TaskMonitor, span: &SpanState) -> RequestTask
 }
 
 pin_project! {
-    /// The future returned by [`RequestMonitor::instrument`].
+    /// The future returned by [`FutureMonitor::instrument`].
     ///
-    /// Wraps the request's future, capturing its per-poll metrics locally and
+    /// Wraps the future, capturing its per-poll metrics locally and
     /// sampling the surrounding task's scheduling delay at each poll. Resolves to
-    /// the wrapped future's output paired with the captured [`RequestTaskMetrics`].
-    pub struct InstrumentedRequest<F> {
+    /// the wrapped future's output paired with the captured [`FutureMetrics`].
+    pub struct MonitoredFuture<F> {
         #[pin]
         inner: Instrumented<F, TaskMonitor>,
         monitor: TaskMonitor,
@@ -3212,21 +3212,21 @@ pin_project! {
     }
 }
 
-impl<F> std::fmt::Debug for InstrumentedRequest<F> {
+impl<F> std::fmt::Debug for MonitoredFuture<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InstrumentedRequest")
+        f.debug_struct("MonitoredFuture")
             .finish_non_exhaustive()
     }
 }
 
-impl<F: Future> Future for InstrumentedRequest<F> {
-    type Output = (F::Output, RequestTaskMetrics);
+impl<F: Future> Future for MonitoredFuture<F> {
+    type Output = (F::Output, FutureMetrics);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         // Sample the root task's scheduling log *before* delegating to the inner
         // `Instrumented`, while the root task's log is the one in scope (the
-        // inner `Instrumented` shadows it with the request's own log during its
+        // inner `Instrumented` shadows it with the future's own log during its
         // poll, which we deliberately ignore).
         this.span
             .record_poll_start(TaskScheduling::try_current().unwrap_or_default());
@@ -3237,7 +3237,7 @@ impl<F: Future> Future for InstrumentedRequest<F> {
         this.span.record_poll_end();
         match ret {
             Poll::Ready(output) => {
-                let metrics = build_request_metrics(this.monitor, this.span);
+                let metrics = build_future_metrics(this.monitor, this.span);
                 Poll::Ready((output, metrics))
             }
             Poll::Pending => Poll::Pending,
@@ -3245,34 +3245,34 @@ impl<F: Future> Future for InstrumentedRequest<F> {
     }
 }
 
-/// Monitors the metrics of a single future — a "request" — running within a
-/// larger, already-[instrumented][TaskMonitor::instrument] task.
+/// Monitors the metrics of a single future running within a larger,
+/// already-[instrumented][TaskMonitor::instrument] task.
 ///
 /// [`TaskMonitor`] aggregates metrics across all the futures it instruments;
-/// `RequestMonitor` instead captures the metrics of *one* future so they can be
-/// attached to that request's own record. Idle, poll, and first-poll metrics are
-/// measured locally from the request's future. Scheduling delay — which only the
+/// `FutureMonitor` instead captures the metrics of *one* future so they can be
+/// attached to that future's own record. Idle, poll, and first-poll metrics are
+/// measured locally from the future. Scheduling delay — which only the
 /// root future the runtime schedules can observe — is read from the surrounding
-/// task's [`TaskScheduling`] log over the request's lifetime, so for scheduling
+/// task's [`TaskScheduling`] log over the future's lifetime, so for scheduling
 /// metrics to be populated the surrounding task must itself be instrumented with
 /// [`TaskMonitor::instrument`].
 ///
-/// `RequestMonitor` instruments exactly one future: [`instrument`] consumes the
+/// `FutureMonitor` instruments exactly one future: [`instrument`] consumes the
 /// monitor, so it cannot be reused, and the returned future resolves to the
-/// wrapped output together with the captured [`RequestTaskMetrics`].
+/// wrapped output together with the captured [`FutureMetrics`].
 ///
 /// ##### Examples
 /// ```
-/// use tokio_metrics::{RequestMonitor, TaskMonitor};
+/// use tokio_metrics::{FutureMonitor, TaskMonitor};
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     // the larger task is instrumented once; `publish_scheduling_delay`
-///     // enables per-request scheduling-delay capture
+///     // enables per-future scheduling-delay capture
 ///     let task_monitor = TaskMonitor::builder().publish_scheduling_delay().build();
 ///     task_monitor.instrument(async {
 ///         // each unit of work within the task is measured on its own
-///         let (_output, metrics) = RequestMonitor::new()
+///         let (_output, metrics) = FutureMonitor::new()
 ///             .instrument(async {
 ///                 tokio::task::yield_now().await;
 ///             })
@@ -3283,38 +3283,38 @@ impl<F: Future> Future for InstrumentedRequest<F> {
 /// }
 /// ```
 ///
-/// [`instrument`]: RequestMonitor::instrument
+/// [`instrument`]: FutureMonitor::instrument
 // Deliberately not `Clone`: cloning would share the underlying span and let two
 // instrumented futures be measured as one, which is exactly the reuse `instrument`
 // (by consuming `self`) is meant to prevent.
 #[derive(Debug, Default)]
-pub struct RequestMonitor {
+pub struct FutureMonitor {
     monitor: TaskMonitor,
     span: Arc<SpanState>,
 }
 
-impl RequestMonitor {
-    /// Constructs a new `RequestMonitor` for a single request.
-    pub fn new() -> RequestMonitor {
-        RequestMonitor::default()
+impl FutureMonitor {
+    /// Constructs a new `FutureMonitor` for a single future.
+    pub fn new() -> FutureMonitor {
+        FutureMonitor::default()
     }
 
-    /// Constructs a new `RequestMonitor` whose local poll metrics use a custom
+    /// Constructs a new `FutureMonitor` whose local poll metrics use a custom
     /// slow-poll threshold (see [`TaskMonitor::with_slow_poll_threshold`]).
-    pub fn with_slow_poll_threshold(slow_poll_threshold: Duration) -> RequestMonitor {
-        RequestMonitor {
+    pub fn with_slow_poll_threshold(slow_poll_threshold: Duration) -> FutureMonitor {
+        FutureMonitor {
             monitor: TaskMonitor::with_slow_poll_threshold(slow_poll_threshold),
             span: Arc::new(SpanState::default()),
         }
     }
 
-    /// Instruments the request's future, consuming the monitor.
+    /// Instruments the future, consuming the monitor.
     ///
-    /// Taking `self` by value means a `RequestMonitor` can only instrument one
-    /// future. Await the returned [`InstrumentedRequest`] to get the future's
-    /// output alongside its [`RequestTaskMetrics`].
-    pub fn instrument<F>(self, task: F) -> InstrumentedRequest<F> {
-        InstrumentedRequest {
+    /// Taking `self` by value means a `FutureMonitor` can only instrument one
+    /// future. Await the returned [`MonitoredFuture`] to get the future's
+    /// output alongside its [`FutureMetrics`].
+    pub fn instrument<F>(self, task: F) -> MonitoredFuture<F> {
+        MonitoredFuture {
             inner: self.monitor.instrument(task),
             monitor: self.monitor,
             span: self.span,
@@ -3499,7 +3499,7 @@ mod inference_tests {
 }
 
 #[cfg(test)]
-mod request_monitor_tests {
+mod future_monitor_tests {
     use super::*;
 
     // Asserts on durations measured by the crate's clock, which is only the
@@ -3507,11 +3507,11 @@ mod request_monitor_tests {
     // `tokio::time::Instant`; without `rt` the crate uses the real `std` clock.
     #[cfg(feature = "rt")]
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn captures_per_request_idle_active_polls() {
+    async fn captures_per_future_idle_active_polls() {
         let task_monitor = TaskMonitor::new();
         task_monitor
             .instrument(async {
-                let (_, m) = RequestMonitor::new()
+                let (_, m) = FutureMonitor::new()
                     .instrument(async {
                         tokio::task::yield_now().await; // an extra poll
                         tokio::time::sleep(Duration::from_secs(1)).await; // idle
@@ -3533,7 +3533,7 @@ mod request_monitor_tests {
     async fn scheduling_is_zero_without_instrumented_root() {
         // No surrounding `TaskMonitor::instrument`, so `try_current()` is `None`
         // and no scheduling delay is attributed — but local metrics still work.
-        let (_, m) = RequestMonitor::new()
+        let (_, m) = FutureMonitor::new()
             .instrument(async {
                 tokio::task::yield_now().await;
             })
@@ -3570,7 +3570,7 @@ mod request_monitor_tests {
     #[tokio::test]
     async fn try_current_is_none_without_opt_in() {
         // A default monitor does not publish the scheduling log, so the common
-        // case pays nothing and `RequestMonitor` scheduling stays zero.
+        // case pays nothing and `FutureMonitor` scheduling stays zero.
         TaskMonitor::new()
             .instrument(async {
                 assert!(TaskScheduling::try_current().is_none());
@@ -3583,7 +3583,7 @@ mod request_monitor_tests {
         // `instrument` consumes the monitor and resolves to the future's output
         // paired with its captured metrics — so a monitor can only ever measure
         // a single future.
-        let (output, m) = RequestMonitor::new()
+        let (output, m) = FutureMonitor::new()
             .instrument(async {
                 tokio::task::yield_now().await;
                 "done"
@@ -3596,11 +3596,11 @@ mod request_monitor_tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn total_duration_includes_final_poll_execution() {
-        // The request completes in a single poll that spends real time
+        // The future completes in a single poll that spends real time
         // executing. `total_duration` is stamped after the poll, so it must
         // include that execution time (a regression would record it before the
         // poll and report ~0).
-        let (_, m) = RequestMonitor::new()
+        let (_, m) = FutureMonitor::new()
             .instrument(async {
                 let start = std::time::Instant::now();
                 while start.elapsed() < Duration::from_millis(20) {}

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,10 +1,11 @@
 use futures_util::task::{ArcWake, AtomicWaker};
 use pin_project_lite::pin_project;
+use std::cell::RefCell;
 use std::future::Future;
 use std::ops::Deref;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::SeqCst};
+use std::sync::{Arc, OnceLock};
 use std::task::{Context, Poll};
 use tokio_stream::Stream;
 
@@ -601,6 +602,12 @@ impl AsRef<TaskMonitorCore> for TaskMonitor {
 #[derive(Debug)]
 pub struct TaskMonitorCore {
     metrics: RawMetrics,
+    /// Whether instrumented tasks should publish their scheduling delay as a
+    /// task-local for [`RequestMonitor`] to sample. Off by default so the common
+    /// case pays nothing; enabled via
+    /// [`TaskMonitorBuilder::record_request_scheduling`]. Kept out of
+    /// [`RawMetrics`] so that struct's (heavily contended) layout is unchanged.
+    record_scheduling_log: bool,
 }
 
 /// Provides an interface for constructing a [`TaskMonitor`] with specialized configuration
@@ -623,6 +630,18 @@ impl TaskMonitorBuilder {
     /// Specifies the threshold at which schedules are considered 'long'.
     pub fn with_long_delay_threshold(&mut self, threshold: Duration) -> &mut Self {
         self.0.long_delay_threshold = Some(threshold);
+        self
+    }
+
+    /// Records each instrumented task's scheduling delay so that a
+    /// [`RequestMonitor`] running within the task can attribute scheduling delay
+    /// to a single request via [`TaskScheduling`].
+    ///
+    /// Off by default: tasks instrumented by a monitor without this enabled pay
+    /// no extra per-poll cost. Enable it on the monitor wrapping the larger task
+    /// when you want [`RequestMonitor`]'s scheduling metrics to be populated.
+    pub fn record_request_scheduling(&mut self) -> &mut Self {
+        self.0.record_scheduling_log = true;
         self
     }
 
@@ -649,6 +668,7 @@ impl TaskMonitorBuilder {
 pub struct TaskMonitorCoreBuilder {
     slow_poll_threshold: Option<Duration>,
     long_delay_threshold: Option<Duration>,
+    record_scheduling_log: bool,
 }
 
 impl TaskMonitorCoreBuilder {
@@ -657,6 +677,7 @@ impl TaskMonitorCoreBuilder {
         Self {
             slow_poll_threshold: None,
             long_delay_threshold: None,
+            record_scheduling_log: false,
         }
     }
 
@@ -676,6 +697,19 @@ impl TaskMonitorCoreBuilder {
         }
     }
 
+    /// Records each instrumented task's scheduling delay so that a
+    /// [`RequestMonitor`] running within the task can attribute scheduling delay
+    /// to a single request via [`TaskScheduling`].
+    ///
+    /// Off by default; see
+    /// [`TaskMonitorBuilder::record_request_scheduling`] for details.
+    pub const fn record_request_scheduling(self) -> Self {
+        Self {
+            record_scheduling_log: true,
+            ..self
+        }
+    }
+
     /// Consume the builder, producing a [`TaskMonitorCore`].
     pub const fn build(self) -> TaskMonitorCore {
         let slow = match self.slow_poll_threshold {
@@ -686,7 +720,7 @@ impl TaskMonitorCoreBuilder {
             Some(v) => v,
             None => TaskMonitor::DEFAULT_LONG_DELAY_THRESHOLD,
         };
-        TaskMonitorCore::create(slow, long)
+        TaskMonitorCore::create(slow, long, self.record_scheduling_log)
     }
 }
 
@@ -1653,6 +1687,105 @@ struct State<M> {
 
     /// Waker to forward notifications to.
     waker: AtomicWaker,
+
+    /// Cumulative scheduling info for this task, published as a task-local while
+    /// the task is being polled so that nested futures (e.g. a per-request
+    /// [`RequestMonitor`]) can attribute scheduling delay to themselves. `None`
+    /// unless the monitor opted in via
+    /// [`TaskMonitorBuilder::record_request_scheduling`], so the common case
+    /// allocates nothing and pays no per-poll cost.
+    log: Option<Arc<SchedulingLog>>,
+}
+
+/// Cumulative scheduling-delay counters for a single instrumented task.
+///
+/// Scheduling delay (the time a task spends in the runtime's queues between
+/// being woken and being polled) is only observable by the root future that the
+/// runtime actually schedules. [`Instrumented`] records it here and publishes
+/// the log as a task-local for the duration of each poll, so that a future
+/// running *within* the task can read the delay accrued during its own lifetime
+/// via [`TaskScheduling::try_current`].
+#[derive(Debug, Default)]
+struct SchedulingLog {
+    scheduled_count: AtomicU64,
+    scheduled_duration_ns: AtomicU64,
+    long_delay_count: AtomicU64,
+}
+
+thread_local! {
+    /// The scheduling log of the innermost [`Instrumented`] task currently being
+    /// polled on this thread, if any.
+    static CURRENT_SCHEDULING_LOG: RefCell<Option<Arc<SchedulingLog>>> =
+        const { RefCell::new(None) };
+}
+
+/// Sets the current task's [`SchedulingLog`] for the duration of a poll,
+/// restoring the previous value on drop. This mirrors what
+/// `tokio::task::LocalKey::sync_scope` does, but without requiring the optional
+/// `tokio` dependency, so it works with and without the `rt` feature.
+struct SchedulingLogGuard(Option<Arc<SchedulingLog>>);
+
+impl SchedulingLogGuard {
+    fn enter(log: Arc<SchedulingLog>) -> Self {
+        let prev = CURRENT_SCHEDULING_LOG.with(|cell| cell.borrow_mut().replace(log));
+        SchedulingLogGuard(prev)
+    }
+}
+
+impl Drop for SchedulingLogGuard {
+    fn drop(&mut self) {
+        let prev = self.0.take();
+        CURRENT_SCHEDULING_LOG.with(|cell| *cell.borrow_mut() = prev);
+    }
+}
+
+/// A snapshot of the cumulative scheduling delay observed by the root
+/// instrumented task that the current future is running on.
+///
+/// Obtain one with [`TaskScheduling::try_current`] from inside a task that has
+/// been instrumented with [`TaskMonitor::instrument`]. Scheduling delay can only
+/// be measured by the root future the runtime schedules, so a future running
+/// within a larger task samples this at two points and reports the difference —
+/// this is exactly what [`RequestMonitor`] does to attribute scheduling delay to
+/// a single request.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TaskScheduling {
+    /// The number of times the task was scheduled (woken, then waiting to be polled).
+    pub scheduled_count: u64,
+    /// The total time the task spent waiting to be polled after being woken.
+    pub total_scheduled_duration: Duration,
+    /// The number of scheduling delays that crossed the monitor's long-delay threshold.
+    pub long_delay_count: u64,
+}
+
+impl TaskScheduling {
+    /// Reads the cumulative scheduling delay of the task currently being polled.
+    ///
+    /// Returns `None` when called outside the poll of a future instrumented with
+    /// [`TaskMonitor::instrument`].
+    pub fn try_current() -> Option<TaskScheduling> {
+        CURRENT_SCHEDULING_LOG.with(|cell| {
+            cell.borrow().as_ref().map(|log| TaskScheduling {
+                scheduled_count: log.scheduled_count.load(SeqCst),
+                total_scheduled_duration: Duration::from_nanos(
+                    log.scheduled_duration_ns.load(SeqCst),
+                ),
+                long_delay_count: log.long_delay_count.load(SeqCst),
+            })
+        })
+    }
+
+    /// The change in each counter relative to an `earlier` snapshot, saturating at zero.
+    fn since(self, earlier: TaskScheduling) -> TaskScheduling {
+        TaskScheduling {
+            scheduled_count: self.scheduled_count.saturating_sub(earlier.scheduled_count),
+            total_scheduled_duration: self
+                .total_scheduled_duration
+                .saturating_sub(earlier.total_scheduled_duration),
+            long_delay_count: self.long_delay_count.saturating_sub(earlier.long_delay_count),
+        }
+    }
 }
 
 impl TaskMonitor {
@@ -1734,7 +1867,8 @@ impl TaskMonitor {
     /// }
     /// ```
     pub fn with_slow_poll_threshold(slow_poll_cut_off: Duration) -> TaskMonitor {
-        let base = TaskMonitorCore::create(slow_poll_cut_off, Self::DEFAULT_LONG_DELAY_THRESHOLD);
+        let base =
+            TaskMonitorCore::create(slow_poll_cut_off, Self::DEFAULT_LONG_DELAY_THRESHOLD, false);
         TaskMonitor {
             base: Arc::new(base),
         }
@@ -1980,7 +2114,11 @@ impl TaskMonitorCore {
     ///
     /// Refer to [`TaskMonitor::with_slow_poll_threshold`] for examples.
     pub const fn with_slow_poll_threshold(slow_poll_cut_off: Duration) -> TaskMonitorCore {
-        Self::create(slow_poll_cut_off, TaskMonitor::DEFAULT_LONG_DELAY_THRESHOLD)
+        Self::create(
+            slow_poll_cut_off,
+            TaskMonitor::DEFAULT_LONG_DELAY_THRESHOLD,
+            false,
+        )
     }
 
     /// Produces the duration greater-than-or-equal-to at which polls are categorized as slow.
@@ -2064,11 +2202,17 @@ impl TaskMonitorCore {
             .instrumented_count
             .fetch_add(1, SeqCst);
 
+        let log = monitor
+            .as_ref()
+            .record_scheduling_log
+            .then(|| Arc::new(SchedulingLog::default()));
+
         let state: State<M> = State {
             monitor,
             instrumented_at: Instant::now(),
             woke_at: AtomicU64::new(0),
             waker: AtomicWaker::new(),
+            log,
         };
 
         let instrumented: Instrumented<F, M> = Instrumented {
@@ -2133,8 +2277,13 @@ impl AsRef<TaskMonitorCore> for TaskMonitorCore {
 }
 
 impl TaskMonitorCore {
-    const fn create(slow_poll_cut_off: Duration, long_delay_cut_off: Duration) -> TaskMonitorCore {
+    const fn create(
+        slow_poll_cut_off: Duration,
+        long_delay_cut_off: Duration,
+        record_scheduling_log: bool,
+    ) -> TaskMonitorCore {
         TaskMonitorCore {
+            record_scheduling_log,
             metrics: RawMetrics {
                 slow_poll_threshold: slow_poll_cut_off,
                 first_poll_count: AtomicU64::new(0),
@@ -2833,15 +2982,36 @@ fn instrument_poll<T, M: AsRef<TaskMonitorCore> + Send + Sync + 'static, Out>(
         metrics
             .total_scheduled_duration_ns
             .fetch_add(scheduled_ns, SeqCst);
+
+        // mirror the same scheduling accounting into this task's own log so that
+        // futures running within the task can attribute scheduling delay to
+        // their own lifetime (see `RequestMonitor`). Only present when the
+        // monitor opted in, so the common case skips this entirely.
+        if let Some(log) = &state.log {
+            log.scheduled_count.fetch_add(1, SeqCst);
+            log.scheduled_duration_ns.fetch_add(scheduled_ns, SeqCst);
+            if scheduled >= metrics.long_delay_threshold {
+                log.long_delay_count.fetch_add(1, SeqCst);
+            }
+        }
     }
     // Register the waker
     state.waker.register(cx.waker());
     // Get the instrumented waker
     let waker_ref = futures_util::task::waker_ref(state);
     let mut cx = Context::from_waker(&waker_ref);
-    // Poll the task
+    // Poll the task, publishing this task's scheduling log as a task-local for
+    // the duration of the poll so nested futures can read it.
     let inner_poll_start = Instant::now();
-    let ret = poll_fn(this.task, &mut cx);
+    // Only publish the task-local when the monitor opted in. When it didn't
+    // (the common case) this is a single predictable branch and the poll path is
+    // byte-for-byte the original — no guard, thread-local, or `Arc` clone.
+    let ret = if let Some(log) = &state.log {
+        let _sched_guard = SchedulingLogGuard::enter(log.clone());
+        poll_fn(this.task, &mut cx)
+    } else {
+        poll_fn(this.task, &mut cx)
+    };
     let inner_poll_end = Instant::now();
     /* idle time starts now */
     *idled_at = inner_poll_end
@@ -2891,6 +3061,230 @@ impl<M: Send + Sync> ArcWake for State<M> {
     fn wake(self: Arc<State<M>>) {
         self.on_wake();
         self.waker.wake();
+    }
+}
+
+/// Key metrics of a single instrumented future — a "request" running within a
+/// larger task — as captured by a [`RequestMonitor`].
+///
+/// Unlike [`TaskMetrics`], which aggregates across every future instrumented by
+/// a [`TaskMonitor`], these metrics describe just one future. Idle, poll, and
+/// first-poll metrics are measured locally from that future's own polls, so they
+/// remain accurate even when the surrounding task interleaves other work.
+/// Scheduling metrics are sampled from the root task's [`TaskScheduling`] log
+/// over the request's lifetime (see [`RequestMonitor`]).
+#[non_exhaustive]
+#[cfg_attr(
+    feature = "metrique-integration",
+    metrique::unit_of_work::metrics(subfield_owned)
+)]
+#[derive(Debug, Clone, Default)]
+pub struct RequestTaskMetrics {
+    /// The number of times the request's future was polled.
+    pub poll_count: u64,
+    /// The total time spent polling the request's future.
+    pub total_poll_duration: Duration,
+    /// The number of polls that exceeded the monitor's slow-poll threshold.
+    pub slow_poll_count: u64,
+    /// The number of times the request idled, waiting to be awoken.
+    pub idle_count: u64,
+    /// The total time the request spent idle, waiting on external events.
+    pub total_idle_duration: Duration,
+    /// The longest single idle the request experienced.
+    pub max_idle_duration: Duration,
+    /// The delay between the request being instrumented and its first poll.
+    pub first_poll_delay: Duration,
+    /// The wall-clock time from the request's first poll to its completion.
+    pub total_duration: Duration,
+    /// The number of times the underlying task was scheduled while the request was alive.
+    pub scheduled_count: u64,
+    /// The total scheduling delay the underlying task incurred while the request was alive.
+    pub total_scheduled_duration: Duration,
+    /// The number of those scheduling delays that crossed the long-delay threshold.
+    pub long_delay_count: u64,
+}
+
+/// Per-request capture state shared between a [`RequestMonitor`] and the
+/// [`InstrumentedRequest`] future it produces.
+#[derive(Debug, Default)]
+struct SpanState {
+    started: AtomicBool,
+    start_scheduled_count: AtomicU64,
+    start_scheduled_duration_ns: AtomicU64,
+    start_long_delay_count: AtomicU64,
+    end_scheduled_count: AtomicU64,
+    end_scheduled_duration_ns: AtomicU64,
+    end_long_delay_count: AtomicU64,
+    first_poll: OnceLock<Instant>,
+    total_duration_ns: AtomicU64,
+}
+
+fn duration_to_nanos(d: Duration) -> u64 {
+    d.as_nanos().try_into().unwrap_or(u64::MAX)
+}
+
+impl SpanState {
+    /// Records the root scheduling snapshot for this poll. Called at the top of
+    /// every poll of the [`InstrumentedRequest`], while the root task's
+    /// scheduling log is in scope.
+    fn record(&self, now: TaskScheduling) {
+        if !self.started.swap(true, SeqCst) {
+            self.start_scheduled_count.store(now.scheduled_count, SeqCst);
+            self.start_scheduled_duration_ns
+                .store(duration_to_nanos(now.total_scheduled_duration), SeqCst);
+            self.start_long_delay_count
+                .store(now.long_delay_count, SeqCst);
+            let _ = self.first_poll.set(Instant::now());
+        }
+        self.end_scheduled_count.store(now.scheduled_count, SeqCst);
+        self.end_scheduled_duration_ns
+            .store(duration_to_nanos(now.total_scheduled_duration), SeqCst);
+        self.end_long_delay_count.store(now.long_delay_count, SeqCst);
+        if let Some(first_poll) = self.first_poll.get() {
+            self.total_duration_ns
+                .store(duration_to_nanos(first_poll.elapsed()), SeqCst);
+        }
+    }
+
+    fn scheduling_delta(&self) -> TaskScheduling {
+        let end = TaskScheduling {
+            scheduled_count: self.end_scheduled_count.load(SeqCst),
+            total_scheduled_duration: Duration::from_nanos(
+                self.end_scheduled_duration_ns.load(SeqCst),
+            ),
+            long_delay_count: self.end_long_delay_count.load(SeqCst),
+        };
+        let start = TaskScheduling {
+            scheduled_count: self.start_scheduled_count.load(SeqCst),
+            total_scheduled_duration: Duration::from_nanos(
+                self.start_scheduled_duration_ns.load(SeqCst),
+            ),
+            long_delay_count: self.start_long_delay_count.load(SeqCst),
+        };
+        end.since(start)
+    }
+
+    fn total_duration(&self) -> Duration {
+        Duration::from_nanos(self.total_duration_ns.load(SeqCst))
+    }
+}
+
+pin_project! {
+    /// The future returned by [`RequestMonitor::instrument`].
+    ///
+    /// Wraps the request's future, capturing its per-poll metrics locally and
+    /// sampling the surrounding task's scheduling delay at each poll.
+    pub struct InstrumentedRequest<F> {
+        #[pin]
+        inner: Instrumented<F, TaskMonitor>,
+        span: Arc<SpanState>,
+    }
+}
+
+impl<F> std::fmt::Debug for InstrumentedRequest<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstrumentedRequest").finish_non_exhaustive()
+    }
+}
+
+impl<F: Future> Future for InstrumentedRequest<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+        let this = self.project();
+        // Sample the root task's scheduling log *before* delegating to the inner
+        // `Instrumented`, while the root task's log is the one in scope (the
+        // inner `Instrumented` shadows it with the request's own log during its
+        // poll, which we deliberately ignore).
+        this.span
+            .record(TaskScheduling::try_current().unwrap_or_default());
+        this.inner.poll(cx)
+    }
+}
+
+/// Monitors the metrics of a single future — a "request" — running within a
+/// larger, already-[instrumented][TaskMonitor::instrument] task.
+///
+/// [`TaskMonitor`] aggregates metrics across all the futures it instruments;
+/// `RequestMonitor` instead captures the metrics of *one* future so they can be
+/// attached to that request's own record. Idle, poll, and first-poll metrics are
+/// measured locally from the request's future. Scheduling delay — which only the
+/// root future the runtime schedules can observe — is read from the surrounding
+/// task's [`TaskScheduling`] log over the request's lifetime, so for scheduling
+/// metrics to be populated the surrounding task must itself be instrumented with
+/// [`TaskMonitor::instrument`].
+///
+/// ##### Examples
+/// ```
+/// use tokio_metrics::{RequestMonitor, TaskMonitor};
+///
+/// #[tokio::main]
+/// async fn main() {
+///     // the larger task is instrumented once; `record_request_scheduling`
+///     // enables per-request scheduling-delay capture
+///     let mut builder = TaskMonitor::builder();
+///     builder.record_request_scheduling();
+///     let task_monitor = builder.build();
+///     task_monitor.instrument(async {
+///         // each unit of work within the task is measured on its own
+///         let request = RequestMonitor::new();
+///         request.instrument(async {
+///             tokio::task::yield_now().await;
+///         }).await;
+///
+///         assert!(request.metrics().poll_count >= 1);
+///     }).await;
+/// }
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct RequestMonitor {
+    monitor: TaskMonitor,
+    span: Arc<SpanState>,
+}
+
+impl RequestMonitor {
+    /// Constructs a new `RequestMonitor` for a single request.
+    pub fn new() -> RequestMonitor {
+        RequestMonitor::default()
+    }
+
+    /// Constructs a new `RequestMonitor` whose local poll metrics use a custom
+    /// slow-poll threshold (see [`TaskMonitor::with_slow_poll_threshold`]).
+    pub fn with_slow_poll_threshold(slow_poll_threshold: Duration) -> RequestMonitor {
+        RequestMonitor {
+            monitor: TaskMonitor::with_slow_poll_threshold(slow_poll_threshold),
+            span: Arc::new(SpanState::default()),
+        }
+    }
+
+    /// Instruments the request's future. Poll it to completion, then read the
+    /// captured metrics with [`metrics`](RequestMonitor::metrics).
+    pub fn instrument<F>(&self, task: F) -> InstrumentedRequest<F> {
+        InstrumentedRequest {
+            inner: self.monitor.instrument(task),
+            span: self.span.clone(),
+        }
+    }
+
+    /// Produces the [`RequestTaskMetrics`] captured so far for this request.
+    ///
+    /// Typically called after the instrumented future has completed.
+    pub fn metrics(&self) -> RequestTaskMetrics {
+        let local = self.monitor.cumulative();
+        let scheduling = self.span.scheduling_delta();
+        RequestTaskMetrics {
+            poll_count: local.total_poll_count,
+            total_poll_duration: local.total_poll_duration,
+            slow_poll_count: local.total_slow_poll_count,
+            idle_count: local.total_idled_count,
+            total_idle_duration: local.total_idle_duration,
+            max_idle_duration: local.max_idle_duration,
+            first_poll_delay: local.total_first_poll_delay,
+            total_duration: self.span.total_duration(),
+            scheduled_count: scheduling.scheduled_count,
+            total_scheduled_duration: scheduling.total_scheduled_duration,
+            long_delay_count: scheduling.long_delay_count,
+        }
     }
 }
 
@@ -3067,5 +3461,92 @@ mod inference_tests {
         _function_boundary(monitor.instrument(async { 42 })).await;
         _return_position(&monitor).await;
         _intervals_inference(&monitor);
+    }
+}
+
+#[cfg(test)]
+mod request_monitor_tests {
+    use super::*;
+
+    // Asserts on durations measured by the crate's clock, which is only the
+    // runtime's virtual clock under `start_paused` when the `rt` feature selects
+    // `tokio::time::Instant`; without `rt` the crate uses the real `std` clock.
+    #[cfg(feature = "rt")]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn captures_per_request_idle_active_polls() {
+        let task_monitor = TaskMonitor::new();
+        task_monitor
+            .instrument(async {
+                let request = RequestMonitor::new();
+                request
+                    .instrument(async {
+                        tokio::task::yield_now().await; // an extra poll
+                        tokio::time::sleep(Duration::from_secs(1)).await; // idle
+                    })
+                    .await;
+
+                let m = request.metrics();
+                assert!(m.poll_count >= 2, "poll_count = {}", m.poll_count);
+                assert!(m.idle_count >= 1, "idle_count = {}", m.idle_count);
+                assert!(
+                    m.total_idle_duration >= Duration::from_secs(1),
+                    "total_idle_duration = {:?}",
+                    m.total_idle_duration
+                );
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn scheduling_is_zero_without_instrumented_root() {
+        // No surrounding `TaskMonitor::instrument`, so `try_current()` is `None`
+        // and no scheduling delay is attributed — but local metrics still work.
+        let request = RequestMonitor::new();
+        request
+            .instrument(async {
+                tokio::task::yield_now().await;
+            })
+            .await;
+
+        let m = request.metrics();
+        assert_eq!(m.scheduled_count, 0);
+        assert_eq!(m.total_scheduled_duration, Duration::ZERO);
+        assert!(m.poll_count >= 1, "poll_count = {}", m.poll_count);
+    }
+
+    #[tokio::test]
+    async fn try_current_tracks_root_scheduling_when_opted_in() {
+        assert!(TaskScheduling::try_current().is_none());
+
+        let mut builder = TaskMonitor::builder();
+        builder.record_request_scheduling();
+        let monitor = builder.build();
+        monitor
+            .instrument(async {
+                // The log exists from the first poll, even before any scheduling.
+                let before = TaskScheduling::try_current().expect("inside instrumented task");
+                tokio::task::yield_now().await;
+                let after = TaskScheduling::try_current().expect("inside instrumented task");
+                assert!(
+                    after.scheduled_count > before.scheduled_count,
+                    "scheduled_count should increase after yielding: {} -> {}",
+                    before.scheduled_count,
+                    after.scheduled_count
+                );
+            })
+            .await;
+
+        assert!(TaskScheduling::try_current().is_none());
+    }
+
+    #[tokio::test]
+    async fn try_current_is_none_without_opt_in() {
+        // A default monitor does not publish the scheduling log, so the common
+        // case pays nothing and `RequestMonitor` scheduling stays zero.
+        TaskMonitor::new()
+            .instrument(async {
+                assert!(TaskScheduling::try_current().is_none());
+            })
+            .await;
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -3103,9 +3103,16 @@ pub struct FutureMetrics {
     pub first_poll_delay: Duration,
     /// The wall-clock time from the future's first poll to its completion.
     pub total_duration: Duration,
-    /// The number of times the underlying task was scheduled while the future was alive.
+    /// The number of times the underlying task was scheduled while this future
+    /// was active.
+    ///
+    /// This tracks the *root* task's scheduling, not this future's polls, so it
+    /// can exceed [`poll_count`](Self::poll_count) — for example when the future
+    /// is one branch of a `select!` and the task is scheduled to advance the
+    /// other branches.
     pub scheduled_count: u64,
-    /// The total scheduling delay the underlying task incurred while the future was alive.
+    /// The total scheduling delay the underlying task incurred while this future
+    /// was active.
     pub total_scheduled_duration: Duration,
     /// The number of those scheduling delays that crossed the long-delay threshold.
     pub long_delay_count: u64,

--- a/src/task.rs
+++ b/src/task.rs
@@ -3131,10 +3131,10 @@ fn duration_to_nanos(d: Duration) -> u64 {
 }
 
 impl SpanState {
-    /// Records the root scheduling snapshot for this poll. Called at the top of
+    /// Records the root scheduling snapshot for a poll. Called at the top of
     /// every poll of the [`InstrumentedRequest`], while the root task's
     /// scheduling log is in scope.
-    fn record(&self, now: TaskScheduling) {
+    fn record_poll_start(&self, now: TaskScheduling) {
         if !self.started.swap(true, SeqCst) {
             self.start_scheduled_count
                 .store(now.scheduled_count, SeqCst);
@@ -3149,6 +3149,11 @@ impl SpanState {
             .store(duration_to_nanos(now.total_scheduled_duration), SeqCst);
         self.end_long_delay_count
             .store(now.long_delay_count, SeqCst);
+    }
+
+    /// Records total elapsed time *after* a poll completes, so the execution
+    /// time of the poll just finished — including the final one — is counted.
+    fn record_poll_end(&self) {
         if let Some(first_poll) = self.first_poll.get() {
             self.total_duration_ns
                 .store(duration_to_nanos(first_poll.elapsed()), SeqCst);
@@ -3207,8 +3212,13 @@ impl<F: Future> Future for InstrumentedRequest<F> {
         // inner `Instrumented` shadows it with the request's own log during its
         // poll, which we deliberately ignore).
         this.span
-            .record(TaskScheduling::try_current().unwrap_or_default());
-        this.inner.poll(cx)
+            .record_poll_start(TaskScheduling::try_current().unwrap_or_default());
+        let ret = this.inner.poll(cx);
+        // Stamp total elapsed *after* the poll so the execution time of the poll
+        // just finished — including the final one that returns `Ready` — is
+        // captured in `total_duration`.
+        this.span.record_poll_end();
+        ret
     }
 }
 
@@ -3558,5 +3568,28 @@ mod request_monitor_tests {
                 assert!(TaskScheduling::try_current().is_none());
             })
             .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn total_duration_includes_final_poll_execution() {
+        // The request completes in a single poll that spends real time
+        // executing. `total_duration` is stamped after the poll, so it must
+        // include that execution time (a regression would record it before the
+        // poll and report ~0).
+        let request = RequestMonitor::new();
+        request
+            .instrument(async {
+                let start = std::time::Instant::now();
+                while start.elapsed() < Duration::from_millis(20) {}
+            })
+            .await;
+
+        let m = request.metrics();
+        assert!(m.poll_count == 1, "poll_count = {}", m.poll_count);
+        assert!(
+            m.total_duration >= Duration::from_millis(15),
+            "total_duration = {:?}",
+            m.total_duration
+        );
     }
 }


### PR DESCRIPTION
Adds RequestMonitor for measuring a single task's behavior: how long it spent idle, running, queued, and how often it was polled instead of only crate-wide aggregates. Scheduling delay comes from an opt-in task-local log,
tasks that don't use it pay nothing.