### PR TITLE
fix: make PollTimeHistogram available without tokio_unstable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,8 @@ cfg_rt! {
     };
 }
 
-#[cfg(all(feature = "rt", tokio_unstable))]
+#[cfg(feature = "rt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub use runtime::{HistogramBucket, PollTimeHistogram};
 
 #[cfg(all(feature = "rt", feature = "metrics-rs-integration"))]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,9 +4,14 @@ use std::ops::Range;
 use std::time::{Duration, Instant};
 use tokio::runtime;
 
-#[cfg(tokio_unstable)]
+// `PollTimeHistogram` and `HistogramBucket` are plain data types (they only
+// hold `Duration`s and counts), so they are always available with the `rt`
+// feature. Only *populating* the histogram requires `tokio_unstable`. Keeping
+// the types ungated ensures `RuntimeMetrics::poll_time_histogram` resolves even
+// when `tokio_unstable` is not set (e.g. when a derive macro re-emits the
+// struct and drops the field's cfg gate). See
+// https://github.com/tokio-rs/tokio-metrics/issues/128.
 mod poll_time_histogram;
-#[cfg(tokio_unstable)]
 pub use poll_time_histogram::{HistogramBucket, PollTimeHistogram};
 
 #[cfg(feature = "metrics-rs-integration")]
@@ -491,8 +496,9 @@ define_runtime_metrics! {
         /// `Vec<u64>`.
         ///
         /// This metric must be explicitly enabled when creating the runtime with
-        /// [`enable_metrics_poll_time_histogram`][tokio::runtime::Builder::enable_metrics_poll_time_histogram].
-        /// Bucket sizes are fixed and configured at the runtime level. See
+        /// [`enable_metrics_poll_time_histogram`][tokio::runtime::Builder::enable_metrics_poll_time_histogram];
+        /// if it is not enabled, the histogram will contain no buckets. Bucket
+        /// sizes are fixed and configured at the runtime level. See
         /// configuration options on
         /// [`runtime::Builder`][tokio::runtime::Builder::enable_metrics_poll_time_histogram].
         ///

--- a/src/runtime/poll_time_histogram.rs
+++ b/src/runtime/poll_time_histogram.rs
@@ -17,6 +17,8 @@ pub struct PollTimeHistogram {
 }
 
 impl PollTimeHistogram {
+    // Only used to populate the histogram, which requires `tokio_unstable`.
+    #[cfg_attr(not(tokio_unstable), allow(dead_code))]
     pub(crate) fn new(buckets: Vec<HistogramBucket>) -> Self {
         Self { buckets }
     }
@@ -26,6 +28,8 @@ impl PollTimeHistogram {
         &self.buckets
     }
 
+    // Only used to populate the histogram, which requires `tokio_unstable`.
+    #[cfg_attr(not(tokio_unstable), allow(dead_code))]
     pub(crate) fn buckets_mut(&mut self) -> &mut [HistogramBucket] {
         &mut self.buckets
     }
@@ -46,6 +50,8 @@ pub struct HistogramBucket {
 }
 
 impl HistogramBucket {
+    // Only used to populate the histogram, which requires `tokio_unstable`.
+    #[cfg_attr(not(tokio_unstable), allow(dead_code))]
     pub(crate) fn new(range_start: Duration, range_end: Duration, count: u64) -> Self {
         Self { range_start, range_end, count }
     }
@@ -66,6 +72,8 @@ impl HistogramBucket {
     }
 
     /// Adds to the count of this bucket.
+    // Only used to populate the histogram, which requires `tokio_unstable`.
+    #[cfg_attr(not(tokio_unstable), allow(dead_code))]
     pub(crate) fn add_count(&mut self, delta: u64) {
         self.count = self.count.saturating_add(delta);
     }
@@ -113,7 +121,10 @@ impl metrique::CloseValue for PollTimeHistogram {
     }
 }
 
-#[cfg(all(test, feature = "metrique-integration"))]
+// `poll_time_histogram_last_bucket_uses_range_start` constructs a
+// `RuntimeMetrics` and reads its `poll_time_histogram` field, both of which
+// require `tokio_unstable`.
+#[cfg(all(test, tokio_unstable, feature = "metrique-integration"))]
 mod tests {
     use super::*;
     use crate::runtime::RuntimeMetrics;


### PR DESCRIPTION
PollTimeHistogram and HistogramBucket are plain data types (they only hold Durations and counts), but the module, the types' re-exports, and the RuntimeMetrics::poll_time_histogram field were all gated on tokio_unstable. When a derive macro (e.g. metrique's Entry derive) re-emits the RuntimeMetrics struct, the field's #[cfg(tokio_unstable)] gate can be dropped, leaving a reference to PollTimeHistogram whose re-export is still gated out. This broke compilation of tokio-metrics with the rt feature but without --cfg tokio_unstable.

Ungate the poll_time_histogram module and the type re-exports so the types are always available with the rt feature. Only populating the histogram requires tokio_unstable, so the crate-internal constructors are allowed to be dead code when it is not set, and the tests that build a RuntimeMetrics remain gated on tokio_unstable.

Fixes #128