### PR TITLE
fix: add explicit Value shape and unit to metrique bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,24 @@ jobs:
     - name: cargo hack check
       run: cargo hack check --each-feature --no-dev-deps --all
 
+  metrique-explicit-impls:
+    # `metrique` defaults `Value::{SHAPE, UNIT}`; this cfg turns those defaults
+    # off so that our metrique bridge is checked for setting them explicitly.
+    # See https://github.com/awslabs/metrique/blob/main/.github/workflows/ci.yml
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: --cfg metrique_require_explicit_impls --cfg tokio_unstable -Dwarnings
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_stable }}
+        override: true
+        profile: minimal
+    - uses: Swatinem/rust-cache@v1
+    - name: cargo check
+      run: cargo check --all --all-targets --all-features
+
   test-versions:
     name: test-version (${{ matrix.name }})
     needs: check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ categories = ["asynchronous", "network-programming"]
 keywords = ["async", "futures", "metrics", "debugging"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tokio_unstable)',
+    'cfg(metrique_require_explicit_impls)',
+] }
 
 [features]
 default = ["rt"]
@@ -29,10 +32,12 @@ futures-util = "0.3.19"
 pin-project-lite = "0.2.7"
 tokio = { version = "1.45.1", features = ["rt", "time", "net"], optional = true }
 metrics = { version = "0.24", optional = true }
-metrique = { version = "0.1.23", default-features = false, optional = true }
+# 0.1.30 pulls in the metrique-writer-core that has `Value::{SHAPE, UNIT}`,
+# which the `PollTimeHistogram` value impl sets explicitly.
+metrique = { version = "0.1.30", default-features = false, optional = true }
 
 [dev-dependencies]
-metrique = { version = "0.1.23", features = ["test-util"] }
+metrique = { version = "0.1.30", features = ["test-util"] }
 axum = "0.8"
 criterion = "0.7"
 futures = "0.3.21"

--- a/src/runtime/poll_time_histogram.rs
+++ b/src/runtime/poll_time_histogram.rs
@@ -81,11 +81,18 @@ impl HistogramBucket {
 
 #[cfg(feature = "metrique-integration")]
 impl metrique::writer::Value for PollTimeHistogram {
-    fn write(&self, writer: impl metrique::writer::ValueWriter) {
-        use metrique::writer::unit::NegativeScale;
-        use metrique::writer::{MetricFlags, Observation, Unit};
+    // Emitted as a distribution of bucket midpoints in microseconds, so the
+    // closed shape is a float rather than the `Opaque` default.
+    const SHAPE: metrique::writer::core::FieldShape<'static> =
+        metrique::writer::core::FieldShape::Known(metrique::writer::core::KnownShape::F64);
+    const UNIT: metrique::writer::Unit = metrique::writer::Unit::Second(
+        metrique::writer::unit::NegativeScale::Micro,
+    );
 
-        // Use the bucket midpoint as the representative value. 
+    fn write(&self, writer: impl metrique::writer::ValueWriter) {
+        use metrique::writer::{MetricFlags, Observation};
+
+        // Use the bucket midpoint as the representative value.
         // Tokio's last bucket has range_end of Duration::from_nanos(u64::MAX),
         // so use range_start for it since the midpoint wouldn't be representative.
         const LAST_BUCKET_END: Duration = Duration::from_nanos(u64::MAX);
@@ -105,7 +112,7 @@ impl metrique::writer::Value for PollTimeHistogram {
                     occurrences: b.count,
                 }
             }),
-            Unit::Second(NegativeScale::Micro),
+            Self::UNIT,
             [],
             MetricFlags::empty(),
         );
@@ -149,6 +156,33 @@ mod tests {
         assert_eq!(buckets[2].count(), 3);
         assert_eq!(buckets[2].range_start(), Duration::from_micros(200));
         assert_eq!(buckets[2].range_end(), Duration::from_micros(500));
+    }
+
+    #[test]
+    fn poll_time_histogram_declares_shape_and_unit() {
+        use metrique::writer::Value;
+        use metrique::writer::core::{FieldShape, KnownShape};
+
+        assert_eq!(
+            <PollTimeHistogram as Value>::SHAPE,
+            FieldShape::Known(KnownShape::F64)
+        );
+
+        let metrics = RuntimeMetrics {
+            poll_time_histogram: PollTimeHistogram::new(vec![HistogramBucket::new(
+                Duration::from_micros(0),
+                Duration::from_micros(100),
+                1,
+            )]),
+            ..Default::default()
+        };
+
+        // The unit reaching the writer must be the one the impl declares.
+        let entry = test_metric(metrics);
+        assert_eq!(
+            entry.metrics["poll_time_histogram"].unit,
+            <PollTimeHistogram as Value>::UNIT
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add explicit Value shape and unit to the metrique bridge, bumping metrique to 0.1.30, so metrique's CI can run its explicit-impls check without excluding metrique-util.
